### PR TITLE
Document testing procedure and patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ npm run dev
 
 The service will be available at `http://localhost:3000` and exposes its endpoints under `/api`.
 
+## Testing
+
+This project uses Node.js's built-in test runner which requires **Node.js v20 or newer**. When you run:
+
+```bash
+npm run test
+```
+
+the `test` script first compiles the TypeScript sources into the `dist/` folder and then executes `node --test` against the generated JavaScript files.
+
 ## Next steps
 
 - Add new slices (for example, managing opportunities or tasks).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite-node src/server.ts",
-    "test": "tsc --outDir dist && node --test dist"
+    "test": "tsc --outDir dist && node --test dist/**/*.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.540.0",


### PR DESCRIPTION
## Summary
- use explicit glob for test runner
- document that tests compile TS first and that Node.js 20+ is required

## Testing
- `npm test` *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68569a6508588328bbab32c9dbfba703