### PR TITLE
Add client aggregate with linking features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project explores building a CRM using **Event Sourcing** in Node.js. The co
 
 ## Goals
 
-- Model CRM entities (for now contacts) as aggregates whose changes are represented by immutable events.
+- Model CRM entities (contacts and clients) as aggregates whose changes are represented by immutable events.
 - Allow the system to grow by adding new slices without affecting the rest of the code.
 - Provide traceability for every operation through a `TraceContext` carried inside the events.
 
@@ -25,6 +25,12 @@ src/
       └─ project-contact/
          ├─ index.ts   # Projection logic
          └─ http.ts    # Endpoint for fetching
+   └─ client/
+      ├─ create-client/
+      ├─ edit-client/
+      ├─ link-contact/
+      ├─ unlink-contact/
+      └─ project-client/
 ```
 
 - **server.ts** registers each slice as an Express router.
@@ -64,6 +70,21 @@ router.post('/contacts', async (req, res) => { /* ... */ });
 
 // 📌 PUT /contacts/:id → Edit contact
 router.put('/contacts/:id', async (req, res) => { /* ... */ });
+```
+
+## Client slice
+
+The client aggregate keeps references to contacts. It provides endpoints for creation, editing and for linking or unlinking contacts:
+
+```ts
+// 📌 POST /clients → Create client
+router.post('/clients', async (req, res) => { /* ... */ });
+
+// 📌 POST /clients/:id/contacts → Link contact
+router.post('/clients/:id/contacts', async (req, res) => { /* ... */ });
+
+// 📌 DELETE /clients/:id/contacts/:contactId → Unlink contact
+router.delete('/clients/:id/contacts/:contactId', async (req, res) => { /* ... */ });
 ```
 
 ## Running

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,11 @@ import express from 'express';
 import createContactRoutes from './slices/contact/create-contact/http.js';
 import editContactRoutes from './slices/contact/edit-contact/http.js';
 import projectContactRoutes from './slices/contact/project-contact/http.js';
+import createClientRoutes from './slices/client/create-client/http.js';
+import editClientRoutes from './slices/client/edit-client/http.js';
+import linkContactRoutes from './slices/client/link-contact/http.js';
+import unlinkContactRoutes from './slices/client/unlink-contact/http.js';
+import projectClientRoutes from './slices/client/project-client/http.js';
 
 const app = express();
 app.use(express.json());
@@ -10,6 +15,11 @@ app.use(express.json());
 app.use('/api', createContactRoutes);
 app.use('/api', editContactRoutes);
 app.use('/api', projectContactRoutes);
+app.use('/api', createClientRoutes);
+app.use('/api', editClientRoutes);
+app.use('/api', linkContactRoutes);
+app.use('/api', unlinkContactRoutes);
+app.use('/api', projectClientRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/src/slices/client/create-client/create-client.test.ts
+++ b/src/slices/client/create-client/create-client.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleCreateClient } from './index.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { Name } from '../value-objects/name.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+test('valid command produces event', () => {
+  const cmd = {
+    clientId: new ClientId('1'),
+    name: new Name('ACME'),
+    trace
+  };
+  const res = handleCreateClient(cmd);
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.value.clientId, '1');
+  }
+});

--- a/src/slices/client/create-client/http.ts
+++ b/src/slices/client/create-client/http.ts
@@ -1,0 +1,61 @@
+import { Router } from 'express';
+import { handleCreateClient } from './index.js';
+import { appendEvent } from '../../../shared/event-store.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { Name } from '../value-objects/name.js';
+
+const router = Router();
+
+function extractTraceFromHeaders(headers: Record<string, unknown>) {
+  return createTraceContext({
+    traceId: headers['x-trace-id']?.toString(),
+    spanId: headers['x-span-id']?.toString(),
+    source: headers['x-source']?.toString() || 'api',
+    userId: headers['x-user-id']?.toString()
+  });
+}
+
+router.post('/clients', async (req, res) => {
+  const trace = extractTraceFromHeaders(req.headers);
+  let cmd;
+  try {
+    cmd = {
+      clientId: new ClientId(req.body.clientId),
+      name: new Name(req.body.name),
+      trace
+    };
+  } catch (err) {
+    const error = err as Error;
+    return res.status(400).json({ error: error.message });
+  }
+
+  const result = handleCreateClient(cmd);
+
+  if (!result.ok) return res.status(400).json({ error: result.error });
+
+  try {
+    await appendEvent(result.value, 'client', result.value.clientId, 1);
+    console.log(`[ClientCreated]`, {
+      traceId: trace.traceId,
+      spanId: trace.spanId,
+      clientId: result.value.clientId
+    });
+    return res.status(201).json({ status: 'ok' });
+  } catch (err) {
+    const error = err as any;
+    if (
+      error.name === 'ConditionalCheckFailedException' ||
+      error.code === 'ConditionalCheckFailedException'
+    ) {
+      return res.status(409).json({
+        error: 'Event already exists — possible duplicate or stale version.'
+      });
+    }
+
+    console.error('[create-client error]', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/src/slices/client/create-client/index.ts
+++ b/src/slices/client/create-client/index.ts
@@ -1,0 +1,33 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { Name } from '../value-objects/name.js';
+
+export type CreateClientCommand = {
+  clientId: ClientId;
+  name: Name;
+  trace: TraceContext;
+};
+
+export type ClientCreatedEvent = {
+  type: 'ClientCreated';
+  clientId: string;
+  name: string;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export function handleCreateClient(
+  cmd: CreateClientCommand
+): Result<ClientCreatedEvent> {
+  const event: ClientCreatedEvent = {
+    type: 'ClientCreated',
+    clientId: cmd.clientId.value,
+    name: cmd.name.value,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/slices/client/edit-client/edit-client.test.ts
+++ b/src/slices/client/edit-client/edit-client.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleEditClient } from './index.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { Name } from '../value-objects/name.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+test('fails when no updates provided', () => {
+  const cmd = { clientId: new ClientId('1'), trace } as any;
+  const res = handleEditClient(cmd);
+  assert.equal(res.ok, false);
+});
+
+test('updates name', () => {
+  const cmd = { clientId: new ClientId('1'), name: new Name('Globex'), trace };
+  const res = handleEditClient(cmd);
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.value.name, 'Globex');
+  }
+});

--- a/src/slices/client/edit-client/http.ts
+++ b/src/slices/client/edit-client/http.ts
@@ -1,0 +1,61 @@
+import { Router } from 'express';
+import { handleEditClient } from './index.js';
+import { appendEvent } from '../../../shared/event-store.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { Name } from '../value-objects/name.js';
+
+const router = Router();
+
+function extractTraceFromHeaders(headers: Record<string, unknown>) {
+  return createTraceContext({
+    traceId: headers['x-trace-id']?.toString(),
+    spanId: headers['x-span-id']?.toString(),
+    source: headers['x-source']?.toString() || 'api',
+    userId: headers['x-user-id']?.toString()
+  });
+}
+
+router.put('/clients/:id', async (req, res) => {
+  const trace = extractTraceFromHeaders(req.headers);
+  let cmd;
+  try {
+    cmd = {
+      clientId: new ClientId(req.params.id),
+      name: req.body.name ? new Name(req.body.name) : undefined,
+      trace
+    };
+  } catch (err) {
+    const error = err as Error;
+    return res.status(400).json({ error: error.message });
+  }
+
+  const result = handleEditClient(cmd);
+
+  if (!result.ok) return res.status(400).json({ error: result.error });
+
+  try {
+    await appendEvent(result.value, 'client', result.value.clientId, 2);
+    console.log(`[ClientEdited]`, {
+      traceId: trace.traceId,
+      spanId: trace.spanId,
+      clientId: result.value.clientId
+    });
+    return res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    const error = err as any;
+    if (
+      error.name === 'ConditionalCheckFailedException' ||
+      error.code === 'ConditionalCheckFailedException'
+    ) {
+      return res.status(409).json({
+        error: 'Event already exists — possible duplicate or stale version.'
+      });
+    }
+
+    console.error('[edit-client error]', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/src/slices/client/edit-client/index.ts
+++ b/src/slices/client/edit-client/index.ts
@@ -1,0 +1,44 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { Name } from '../value-objects/name.js';
+
+export type EditClientCommand = {
+  clientId: ClientId;
+  name?: Name;
+  trace: TraceContext;
+};
+
+export type ClientEditedEvent = {
+  type: 'ClientEdited';
+  clientId: string;
+  name?: string;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function validate(cmd: EditClientCommand): Result<EditClientCommand> {
+  if (!cmd.name) {
+    return { ok: false, error: 'nothing to update' };
+  }
+
+  return { ok: true, value: cmd };
+}
+
+export function handleEditClient(
+  cmd: EditClientCommand
+): Result<ClientEditedEvent> {
+  const valid = validate(cmd);
+  if (!valid.ok) return { ok: false, error: valid.error };
+
+  const event: ClientEditedEvent = {
+    type: 'ClientEdited',
+    clientId: cmd.clientId.value,
+    name: cmd.name?.value,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/slices/client/link-contact/http.ts
+++ b/src/slices/client/link-contact/http.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import { handleLinkContact } from './index.js';
+import { appendEvent } from '../../../shared/event-store.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { ContactId } from '../../contact/value-objects/contact-id.js';
+
+const router = Router();
+
+function extractTraceFromHeaders(headers: Record<string, unknown>) {
+  return createTraceContext({
+    traceId: headers['x-trace-id']?.toString(),
+    spanId: headers['x-span-id']?.toString(),
+    source: headers['x-source']?.toString() || 'api',
+    userId: headers['x-user-id']?.toString()
+  });
+}
+
+router.post('/clients/:id/contacts', async (req, res) => {
+  const trace = extractTraceFromHeaders(req.headers);
+  let cmd;
+  try {
+    cmd = {
+      clientId: new ClientId(req.params.id),
+      contactId: new ContactId(req.body.contactId),
+      trace
+    };
+  } catch (err) {
+    const error = err as Error;
+    return res.status(400).json({ error: error.message });
+  }
+
+  const result = handleLinkContact(cmd);
+
+  if (!result.ok) return res.status(400).json({ error: result.error });
+
+  try {
+    await appendEvent(result.value, 'client', result.value.clientId, 3);
+    console.log(`[ContactLinked]`, {
+      traceId: trace.traceId,
+      spanId: trace.spanId,
+      clientId: result.value.clientId,
+      contactId: result.value.contactId
+    });
+    return res.status(201).json({ status: 'ok' });
+  } catch (err) {
+    const error = err as any;
+    if (
+      error.name === 'ConditionalCheckFailedException' ||
+      error.code === 'ConditionalCheckFailedException'
+    ) {
+      return res.status(409).json({
+        error: 'Event already exists — possible duplicate or stale version.'
+      });
+    }
+
+    console.error('[link-contact error]', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/src/slices/client/link-contact/index.ts
+++ b/src/slices/client/link-contact/index.ts
@@ -1,0 +1,33 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { ContactId } from '../../contact/value-objects/contact-id.js';
+
+export type LinkContactCommand = {
+  clientId: ClientId;
+  contactId: ContactId;
+  trace: TraceContext;
+};
+
+export type ContactLinkedEvent = {
+  type: 'ContactLinked';
+  clientId: string;
+  contactId: string;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export function handleLinkContact(
+  cmd: LinkContactCommand
+): Result<ContactLinkedEvent> {
+  const event: ContactLinkedEvent = {
+    type: 'ContactLinked',
+    clientId: cmd.clientId.value,
+    contactId: cmd.contactId.value,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/slices/client/link-contact/link-contact.test.ts
+++ b/src/slices/client/link-contact/link-contact.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleLinkContact } from './index.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { ContactId } from '../../contact/value-objects/contact-id.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+test('links contact', () => {
+  const cmd = {
+    clientId: new ClientId('1'),
+    contactId: new ContactId('c1'),
+    trace
+  };
+  const res = handleLinkContact(cmd);
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.value.contactId, 'c1');
+  }
+});

--- a/src/slices/client/project-client/http.ts
+++ b/src/slices/client/project-client/http.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { projectClient } from './index.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import { getEventsForAggregate } from '../../../shared/event-store.js';
+
+const router = Router();
+
+function extractTraceFromHeaders(headers: Record<string, unknown>) {
+  return createTraceContext({
+    traceId: headers['x-trace-id']?.toString(),
+    spanId: headers['x-span-id']?.toString(),
+    source: headers['x-source']?.toString() || 'api',
+    userId: headers['x-user-id']?.toString()
+  });
+}
+
+router.get('/clients/:id', async (req, res) => {
+  const trace = extractTraceFromHeaders(req.headers);
+  const clientId = req.params.id;
+
+  try {
+    const events = await getEventsForAggregate('client', clientId);
+    const state = projectClient(events);
+
+    if (!state) {
+      return res.status(404).json({ error: 'Client not found' });
+    }
+
+    console.log(`[ClientFetched]`, { traceId: trace.traceId, spanId: trace.spanId, clientId });
+    return res.status(200).json(state);
+  } catch (err) {
+    console.error('[get-client error]', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/src/slices/client/project-client/index.ts
+++ b/src/slices/client/project-client/index.ts
@@ -1,0 +1,47 @@
+export type ClientState = {
+  clientId: string;
+  name?: string;
+  contactIds: string[];
+  version: number;
+};
+
+export function projectClient(events: any[]): ClientState | null {
+  if (!events.length) return null;
+
+  const state: ClientState = {
+    clientId: '',
+    contactIds: [],
+    version: 0
+  };
+
+  for (const event of events) {
+    switch (event.type) {
+      case 'ClientCreated':
+        state.clientId = event.clientId;
+        state.name = event.name;
+        state.version += 1;
+        break;
+
+      case 'ClientEdited':
+        if (event.name) state.name = event.name;
+        state.version += 1;
+        break;
+
+      case 'ContactLinked':
+        if (!state.contactIds.includes(event.contactId)) {
+          state.contactIds.push(event.contactId);
+        }
+        state.version += 1;
+        break;
+
+      case 'ContactUnlinked':
+        state.contactIds = state.contactIds.filter(
+          (id) => id !== event.contactId
+        );
+        state.version += 1;
+        break;
+    }
+  }
+
+  return state;
+}

--- a/src/slices/client/project-client/project-client.test.ts
+++ b/src/slices/client/project-client/project-client.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { projectClient } from './index.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+const created = {
+  type: 'ClientCreated',
+  clientId: '1',
+  name: 'ACME',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+const linked = {
+  type: 'ContactLinked',
+  clientId: '1',
+  contactId: 'c1',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+test('returns null for empty events', () => {
+  assert.equal(projectClient([]), null);
+});
+
+test('projects latest state', () => {
+  const state = projectClient([created, linked]);
+  assert.equal(state?.contactIds.length, 1);
+  assert.equal(state?.version, 2);
+});

--- a/src/slices/client/unlink-contact/http.ts
+++ b/src/slices/client/unlink-contact/http.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import { handleUnlinkContact } from './index.js';
+import { appendEvent } from '../../../shared/event-store.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { ContactId } from '../../contact/value-objects/contact-id.js';
+
+const router = Router();
+
+function extractTraceFromHeaders(headers: Record<string, unknown>) {
+  return createTraceContext({
+    traceId: headers['x-trace-id']?.toString(),
+    spanId: headers['x-span-id']?.toString(),
+    source: headers['x-source']?.toString() || 'api',
+    userId: headers['x-user-id']?.toString()
+  });
+}
+
+router.delete('/clients/:id/contacts/:contactId', async (req, res) => {
+  const trace = extractTraceFromHeaders(req.headers);
+  let cmd;
+  try {
+    cmd = {
+      clientId: new ClientId(req.params.id),
+      contactId: new ContactId(req.params.contactId),
+      trace
+    };
+  } catch (err) {
+    const error = err as Error;
+    return res.status(400).json({ error: error.message });
+  }
+
+  const result = handleUnlinkContact(cmd);
+
+  if (!result.ok) return res.status(400).json({ error: result.error });
+
+  try {
+    await appendEvent(result.value, 'client', result.value.clientId, 4);
+    console.log(`[ContactUnlinked]`, {
+      traceId: trace.traceId,
+      spanId: trace.spanId,
+      clientId: result.value.clientId,
+      contactId: result.value.contactId
+    });
+    return res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    const error = err as any;
+    if (
+      error.name === 'ConditionalCheckFailedException' ||
+      error.code === 'ConditionalCheckFailedException'
+    ) {
+      return res.status(409).json({
+        error: 'Event already exists — possible duplicate or stale version.'
+      });
+    }
+
+    console.error('[unlink-contact error]', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/src/slices/client/unlink-contact/index.ts
+++ b/src/slices/client/unlink-contact/index.ts
@@ -1,0 +1,33 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { ContactId } from '../../contact/value-objects/contact-id.js';
+
+export type UnlinkContactCommand = {
+  clientId: ClientId;
+  contactId: ContactId;
+  trace: TraceContext;
+};
+
+export type ContactUnlinkedEvent = {
+  type: 'ContactUnlinked';
+  clientId: string;
+  contactId: string;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export function handleUnlinkContact(
+  cmd: UnlinkContactCommand
+): Result<ContactUnlinkedEvent> {
+  const event: ContactUnlinkedEvent = {
+    type: 'ContactUnlinked',
+    clientId: cmd.clientId.value,
+    contactId: cmd.contactId.value,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/slices/client/unlink-contact/unlink-contact.test.ts
+++ b/src/slices/client/unlink-contact/unlink-contact.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleUnlinkContact } from './index.js';
+import { ClientId } from '../value-objects/client-id.js';
+import { ContactId } from '../../contact/value-objects/contact-id.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+test('unlinks contact', () => {
+  const cmd = {
+    clientId: new ClientId('1'),
+    contactId: new ContactId('c1'),
+    trace
+  };
+  const res = handleUnlinkContact(cmd);
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.value.contactId, 'c1');
+  }
+});

--- a/src/slices/client/value-objects/client-id.ts
+++ b/src/slices/client/value-objects/client-id.ts
@@ -1,0 +1,9 @@
+export class ClientId {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim() === '') {
+      throw new Error('clientId is required');
+    }
+    this.value = value;
+  }
+}

--- a/src/slices/client/value-objects/name.ts
+++ b/src/slices/client/value-objects/name.ts
@@ -1,0 +1,9 @@
+export class Name {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim().length < 2) {
+      throw new Error('name must be at least 2 characters');
+    }
+    this.value = value;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce client aggregate with create/edit/link/unlink slices
- add projections for client state
- register client routers in the server
- document client slices in the README

## Testing
- `npm run test` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6856d8bfbd0483288e608c6125edd967