### PR TITLE
Refactor slices to use dependency injection

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,30 +1,16 @@
 import express from 'express';
-import createContactRoutes from './slices/contact/create-contact/http.js';
-import editContactRoutes from './slices/contact/edit-contact/http.js';
-import projectContactRoutes from './slices/contact/project-contact/http.js';
-import createClientRoutes from './slices/client/create-client/http.js';
-import editClientRoutes from './slices/client/edit-client/http.js';
-import linkContactRoutes from './slices/client/link-contact/http.js';
-import unlinkContactRoutes from './slices/client/unlink-contact/http.js';
-import projectClientRoutes from './slices/client/project-client/http.js';
-import deleteContactRoutes from './slices/contact/delete-contact/http.js';
-import { registerUnlinkOnContactDeleted } from './slices/client/unlink-contact/subscription.js';
+import { eventStore } from './shared/event-store.js';
+import { ClientSlice } from './slices/client/index.js';
+import { ContactSlice } from './slices/contact/index.js';
 
 const app = express();
 app.use(express.json());
 
-// Register each contact slice router
-app.use('/api', createContactRoutes);
-app.use('/api', editContactRoutes);
-app.use('/api', projectContactRoutes);
-app.use('/api', deleteContactRoutes);
-app.use('/api', createClientRoutes);
-app.use('/api', editClientRoutes);
-app.use('/api', linkContactRoutes);
-app.use('/api', unlinkContactRoutes);
-app.use('/api', projectClientRoutes);
+const router = express.Router();
+app.use('/api', router);
 
-registerUnlinkOnContactDeleted();
+new ContactSlice(router, eventStore);
+new ClientSlice(router, eventStore);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/src/shared/event-store.ts
+++ b/src/shared/event-store.ts
@@ -128,3 +128,15 @@ export async function appendEvent(
 
   await docClient.send(new TransactWriteCommand({ TransactItems: transactItems }));
 }
+
+export interface EventStore {
+  appendEvent: typeof appendEvent;
+  getEventsForAggregate: typeof getEventsForAggregate;
+  subscribe: typeof subscribe;
+}
+
+export const eventStore: EventStore = {
+  appendEvent,
+  getEventsForAggregate,
+  subscribe
+};

--- a/src/shared/slice.ts
+++ b/src/shared/slice.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import type { EventStore } from './event-store.js';
+
+/** Marker interface for slice classes */
+export interface Slice {
+  // Slices configure routes and subscriptions when instantiated
+}
+
+export type SliceConstructor = new (router: Router, eventStore: EventStore) => Slice;

--- a/src/slices/client/create-client/http.ts
+++ b/src/slices/client/create-client/http.ts
@@ -1,61 +1,60 @@
 import { Router } from 'express';
 import { handleCreateClient } from './index.js';
-import { appendEvent } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
 
-const router = Router();
+export function registerCreateClientRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.post('/clients', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    let cmd;
+    try {
+      cmd = {
+        clientId: new ClientId(req.body.clientId),
+        name: new Name(req.body.name),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleCreateClient(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 1);
+      console.log(`[ClientCreated]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        clientId: result.value.clientId
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[create-client error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.post('/clients', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  let cmd;
-  try {
-    cmd = {
-      clientId: new ClientId(req.body.clientId),
-      name: new Name(req.body.name),
-      trace
-    };
-  } catch (err) {
-    const error = err as Error;
-    return res.status(400).json({ error: error.message });
-  }
-
-  const result = handleCreateClient(cmd);
-
-  if (!result.ok) return res.status(400).json({ error: result.error });
-
-  try {
-    await appendEvent(result.value, 'client', result.value.clientId, 1);
-    console.log(`[ClientCreated]`, {
-      traceId: trace.traceId,
-      spanId: trace.spanId,
-      clientId: result.value.clientId
-    });
-    return res.status(201).json({ status: 'ok' });
-  } catch (err) {
-    const error = err as any;
-    if (
-      error.name === 'ConditionalCheckFailedException' ||
-      error.code === 'ConditionalCheckFailedException'
-    ) {
-      return res.status(409).json({
-        error: 'Event already exists — possible duplicate or stale version.'
-      });
-    }
-
-    console.error('[create-client error]', error);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/client/edit-client/http.ts
+++ b/src/slices/client/edit-client/http.ts
@@ -1,61 +1,60 @@
 import { Router } from 'express';
 import { handleEditClient } from './index.js';
-import { appendEvent } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
 
-const router = Router();
+export function registerEditClientRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.put('/clients/:id', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    let cmd;
+    try {
+      cmd = {
+        clientId: new ClientId(req.params.id),
+        name: req.body.name ? new Name(req.body.name) : undefined,
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleEditClient(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 2);
+      console.log(`[ClientEdited]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        clientId: result.value.clientId
+      });
+      return res.status(200).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[edit-client error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.put('/clients/:id', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  let cmd;
-  try {
-    cmd = {
-      clientId: new ClientId(req.params.id),
-      name: req.body.name ? new Name(req.body.name) : undefined,
-      trace
-    };
-  } catch (err) {
-    const error = err as Error;
-    return res.status(400).json({ error: error.message });
-  }
-
-  const result = handleEditClient(cmd);
-
-  if (!result.ok) return res.status(400).json({ error: result.error });
-
-  try {
-    await appendEvent(result.value, 'client', result.value.clientId, 2);
-    console.log(`[ClientEdited]`, {
-      traceId: trace.traceId,
-      spanId: trace.spanId,
-      clientId: result.value.clientId
-    });
-    return res.status(200).json({ status: 'ok' });
-  } catch (err) {
-    const error = err as any;
-    if (
-      error.name === 'ConditionalCheckFailedException' ||
-      error.code === 'ConditionalCheckFailedException'
-    ) {
-      return res.status(409).json({
-        error: 'Event already exists — possible duplicate or stale version.'
-      });
-    }
-
-    console.error('[edit-client error]', error);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/client/index.ts
+++ b/src/slices/client/index.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import type { EventStore } from '../../shared/event-store.js';
+import type { Slice } from '../../shared/slice.js';
+import { registerCreateClientRoutes } from './create-client/http.js';
+import { registerEditClientRoutes } from './edit-client/http.js';
+import { registerLinkContactRoutes } from './link-contact/http.js';
+import { registerUnlinkContactRoutes } from './unlink-contact/http.js';
+import { registerProjectClientRoutes } from './project-client/http.js';
+import { registerUnlinkOnContactDeleted } from './unlink-contact/subscription.js';
+
+export class ClientSlice implements Slice {
+  constructor(router: Router, eventStore: EventStore) {
+    registerCreateClientRoutes(router, eventStore);
+    registerEditClientRoutes(router, eventStore);
+    registerLinkContactRoutes(router, eventStore);
+    registerUnlinkContactRoutes(router, eventStore);
+    registerProjectClientRoutes(router, eventStore);
+    registerUnlinkOnContactDeleted(eventStore);
+  }
+}

--- a/src/slices/client/link-contact/http.ts
+++ b/src/slices/client/link-contact/http.ts
@@ -1,62 +1,61 @@
 import { Router } from 'express';
 import { handleLinkContact } from './index.js';
-import { appendEvent } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { ContactId } from '../../contact/value-objects/contact-id.js';
 
-const router = Router();
+export function registerLinkContactRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.post('/clients/:id/contacts', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    let cmd;
+    try {
+      cmd = {
+        clientId: new ClientId(req.params.id),
+        contactId: new ContactId(req.body.contactId),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleLinkContact(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 3);
+      console.log(`[ContactLinked]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        clientId: result.value.clientId,
+        contactId: result.value.contactId
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[link-contact error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.post('/clients/:id/contacts', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  let cmd;
-  try {
-    cmd = {
-      clientId: new ClientId(req.params.id),
-      contactId: new ContactId(req.body.contactId),
-      trace
-    };
-  } catch (err) {
-    const error = err as Error;
-    return res.status(400).json({ error: error.message });
-  }
-
-  const result = handleLinkContact(cmd);
-
-  if (!result.ok) return res.status(400).json({ error: result.error });
-
-  try {
-    await appendEvent(result.value, 'client', result.value.clientId, 3);
-    console.log(`[ContactLinked]`, {
-      traceId: trace.traceId,
-      spanId: trace.spanId,
-      clientId: result.value.clientId,
-      contactId: result.value.contactId
-    });
-    return res.status(201).json({ status: 'ok' });
-  } catch (err) {
-    const error = err as any;
-    if (
-      error.name === 'ConditionalCheckFailedException' ||
-      error.code === 'ConditionalCheckFailedException'
-    ) {
-      return res.status(409).json({
-        error: 'Event already exists — possible duplicate or stale version.'
-      });
-    }
-
-    console.error('[link-contact error]', error);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/client/project-client/http.ts
+++ b/src/slices/client/project-client/http.ts
@@ -1,37 +1,36 @@
 import { Router } from 'express';
 import { projectClient } from './index.js';
 import { createTraceContext } from '../../../shared/trace.js';
-import { getEventsForAggregate } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 
-const router = Router();
+export function registerProjectClientRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.get('/clients/:id', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    const clientId = req.params.id;
+
+    try {
+      const events = await eventStore.getEventsForAggregate('client', clientId);
+      const state = projectClient(events);
+
+      if (!state) {
+        return res.status(404).json({ error: 'Client not found' });
+      }
+
+      console.log(`[ClientFetched]`, { traceId: trace.traceId, spanId: trace.spanId, clientId });
+      return res.status(200).json(state);
+    } catch (err) {
+      console.error('[get-client error]', err);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.get('/clients/:id', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  const clientId = req.params.id;
-
-  try {
-    const events = await getEventsForAggregate('client', clientId);
-    const state = projectClient(events);
-
-    if (!state) {
-      return res.status(404).json({ error: 'Client not found' });
-    }
-
-    console.log(`[ClientFetched]`, { traceId: trace.traceId, spanId: trace.spanId, clientId });
-    return res.status(200).json(state);
-  } catch (err) {
-    console.error('[get-client error]', err);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/client/unlink-contact/http.ts
+++ b/src/slices/client/unlink-contact/http.ts
@@ -1,62 +1,61 @@
 import { Router } from 'express';
 import { handleUnlinkContact } from './index.js';
-import { appendEvent } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { ContactId } from '../../contact/value-objects/contact-id.js';
 
-const router = Router();
+export function registerUnlinkContactRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.delete('/clients/:id/contacts/:contactId', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    let cmd;
+    try {
+      cmd = {
+        clientId: new ClientId(req.params.id),
+        contactId: new ContactId(req.params.contactId),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleUnlinkContact(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 4);
+      console.log(`[ContactUnlinked]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        clientId: result.value.clientId,
+        contactId: result.value.contactId
+      });
+      return res.status(200).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[unlink-contact error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.delete('/clients/:id/contacts/:contactId', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  let cmd;
-  try {
-    cmd = {
-      clientId: new ClientId(req.params.id),
-      contactId: new ContactId(req.params.contactId),
-      trace
-    };
-  } catch (err) {
-    const error = err as Error;
-    return res.status(400).json({ error: error.message });
-  }
-
-  const result = handleUnlinkContact(cmd);
-
-  if (!result.ok) return res.status(400).json({ error: result.error });
-
-  try {
-    await appendEvent(result.value, 'client', result.value.clientId, 4);
-    console.log(`[ContactUnlinked]`, {
-      traceId: trace.traceId,
-      spanId: trace.spanId,
-      clientId: result.value.clientId,
-      contactId: result.value.contactId
-    });
-    return res.status(200).json({ status: 'ok' });
-  } catch (err) {
-    const error = err as any;
-    if (
-      error.name === 'ConditionalCheckFailedException' ||
-      error.code === 'ConditionalCheckFailedException'
-    ) {
-      return res.status(409).json({
-        error: 'Event already exists — possible duplicate or stale version.'
-      });
-    }
-
-    console.error('[unlink-contact error]', error);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/client/unlink-contact/subscription.ts
+++ b/src/slices/client/unlink-contact/subscription.ts
@@ -1,10 +1,10 @@
-import { subscribe, AppendDirective } from '../../../shared/event-store.js';
+import type { EventStore, AppendDirective } from '../../../shared/event-store.js';
 import { handleUnlinkContact } from './index.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { ContactId } from '../../contact/value-objects/contact-id.js';
 
-export function registerUnlinkOnContactDeleted() {
-  subscribe('ContactDeleted', (event) => {
+export function registerUnlinkOnContactDeleted(eventStore: EventStore) {
+  eventStore.subscribe('ContactDeleted', (event) => {
     if (!event.cascade) {
       return { cancel: true } as AppendDirective;
     }

--- a/src/slices/contact/create-contact/http.ts
+++ b/src/slices/contact/create-contact/http.ts
@@ -1,63 +1,62 @@
 import { Router } from 'express';
 import { handleCreateContact } from './index.js';
-import { appendEvent } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
 
-const router = Router();
+export function registerCreateContactRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.post('/contacts', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    let cmd;
+    try {
+      cmd = {
+        contactId: new ContactId(req.body.contactId),
+        name: new Name(req.body.name),
+        email: new Mail(req.body.email),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleCreateContact(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      await eventStore.appendEvent(result.value, 'contact', result.value.contactId, 1);
+      console.log(`[ContactCreated]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        contactId: result.value.contactId
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[create-contact error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.post('/contacts', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  let cmd;
-  try {
-    cmd = {
-      contactId: new ContactId(req.body.contactId),
-      name: new Name(req.body.name),
-      email: new Mail(req.body.email),
-      trace
-    };
-  } catch (err) {
-    const error = err as Error;
-    return res.status(400).json({ error: error.message });
-  }
-
-  const result = handleCreateContact(cmd);
-
-  if (!result.ok) return res.status(400).json({ error: result.error });
-
-  try {
-    await appendEvent(result.value, 'contact', result.value.contactId, 1);
-    console.log(`[ContactCreated]`, {
-      traceId: trace.traceId,
-      spanId: trace.spanId,
-      contactId: result.value.contactId
-    });
-    return res.status(201).json({ status: 'ok' });
-  } catch (err) {
-    const error = err as any;
-    if (
-      error.name === 'ConditionalCheckFailedException' ||
-      error.code === 'ConditionalCheckFailedException'
-    ) {
-      return res.status(409).json({
-        error: 'Event already exists — possible duplicate or stale version.'
-      });
-    }
-
-    console.error('[create-contact error]', error);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/contact/delete-contact/http.ts
+++ b/src/slices/contact/delete-contact/http.ts
@@ -1,64 +1,63 @@
 import { Router } from 'express';
 import { handleDeleteContact } from './index.js';
-import { appendEvent } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { ClientId } from '../../client/value-objects/client-id.js';
 
-const router = Router();
+export function registerDeleteContactRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.delete('/contacts/:id', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    const cascade = req.query.cascade === 'true';
+    let cmd;
+    try {
+      cmd = {
+        contactId: new ContactId(req.params.id),
+        clientId: new ClientId(req.query.clientId as string),
+        cascade,
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleDeleteContact(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      const version = 3; // TODO: real version
+      await eventStore.appendEvent(result.value, 'contact', cmd.contactId.value, version);
+      console.log(`[ContactDeleted]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        contactId: cmd.contactId.value
+      });
+      return res.status(200).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[delete-contact error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.delete('/contacts/:id', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  const cascade = req.query.cascade === 'true';
-  let cmd;
-  try {
-    cmd = {
-      contactId: new ContactId(req.params.id),
-      clientId: new ClientId(req.query.clientId as string),
-      cascade,
-      trace
-    };
-  } catch (err) {
-    const error = err as Error;
-    return res.status(400).json({ error: error.message });
-  }
-
-  const result = handleDeleteContact(cmd);
-
-  if (!result.ok) return res.status(400).json({ error: result.error });
-
-  try {
-    const version = 3; // TODO: real version
-    await appendEvent(result.value, 'contact', cmd.contactId.value, version);
-    console.log(`[ContactDeleted]`, {
-      traceId: trace.traceId,
-      spanId: trace.spanId,
-      contactId: cmd.contactId.value
-    });
-    return res.status(200).json({ status: 'ok' });
-  } catch (err) {
-    const error = err as any;
-    if (
-      error.name === 'ConditionalCheckFailedException' ||
-      error.code === 'ConditionalCheckFailedException'
-    ) {
-      return res.status(409).json({
-        error: 'Event already exists — possible duplicate or stale version.'
-      });
-    }
-
-    console.error('[delete-contact error]', error);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/contact/edit-contact/http.ts
+++ b/src/slices/contact/edit-contact/http.ts
@@ -1,63 +1,62 @@
 import { Router } from 'express';
 import { handleEditContact } from './index.js';
-import { appendEvent } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
 
-const router = Router();
+export function registerEditContactRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.put('/contacts/:id', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    let cmd;
+    try {
+      cmd = {
+        contactId: new ContactId(req.params.id),
+        name: req.body.name !== undefined ? new Name(req.body.name) : undefined,
+        email: req.body.email !== undefined ? new Mail(req.body.email) : undefined,
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleEditContact(cmd);
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      const version = 2; // TODO: real version
+      await eventStore.appendEvent(result.value, 'contact', cmd.contactId.value, version);
+      console.log(`[ContactEdited]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        contactId: cmd.contactId.value
+      });
+      return res.status(200).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[edit-contact error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.put('/contacts/:id', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  let cmd;
-  try {
-    cmd = {
-      contactId: new ContactId(req.params.id),
-      name: req.body.name !== undefined ? new Name(req.body.name) : undefined,
-      email: req.body.email !== undefined ? new Mail(req.body.email) : undefined,
-      trace
-    };
-  } catch (err) {
-    const error = err as Error;
-    return res.status(400).json({ error: error.message });
-  }
-
-  const result = handleEditContact(cmd);
-  if (!result.ok) return res.status(400).json({ error: result.error });
-
-  try {
-    const version = 2; // TODO: real version
-    await appendEvent(result.value, 'contact', cmd.contactId.value, version);
-    console.log(`[ContactEdited]`, {
-      traceId: trace.traceId,
-      spanId: trace.spanId,
-      contactId: cmd.contactId.value
-    });
-    return res.status(200).json({ status: 'ok' });
-  } catch (err) {
-    const error = err as any;
-    if (
-      error.name === 'ConditionalCheckFailedException' ||
-      error.code === 'ConditionalCheckFailedException'
-    ) {
-      return res.status(409).json({
-        error: 'Event already exists — possible duplicate or stale version.'
-      });
-    }
-
-    console.error('[edit-contact error]', error);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;

--- a/src/slices/contact/index.ts
+++ b/src/slices/contact/index.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import type { EventStore } from '../../shared/event-store.js';
+import type { Slice } from '../../shared/slice.js';
+import { registerCreateContactRoutes } from './create-contact/http.js';
+import { registerEditContactRoutes } from './edit-contact/http.js';
+import { registerDeleteContactRoutes } from './delete-contact/http.js';
+import { registerProjectContactRoutes } from './project-contact/http.js';
+
+export class ContactSlice implements Slice {
+  constructor(router: Router, eventStore: EventStore) {
+    registerCreateContactRoutes(router, eventStore);
+    registerEditContactRoutes(router, eventStore);
+    registerDeleteContactRoutes(router, eventStore);
+    registerProjectContactRoutes(router, eventStore);
+  }
+}

--- a/src/slices/contact/project-contact/http.ts
+++ b/src/slices/contact/project-contact/http.ts
@@ -1,38 +1,37 @@
 import { Router } from 'express';
 import { projectContact } from './index.js';
 import { createTraceContext } from '../../../shared/trace.js';
-import { getEventsForAggregate } from '../../../shared/event-store.js';
+import type { EventStore } from '../../../shared/event-store.js';
 
-const router = Router();
+export function registerProjectContactRoutes(router: Router, eventStore: EventStore) {
+  // Reuse same helper as others
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
 
-// Reuse same helper as others
-function extractTraceFromHeaders(headers: Record<string, unknown>) {
-  return createTraceContext({
-    traceId: headers['x-trace-id']?.toString(),
-    spanId: headers['x-span-id']?.toString(),
-    source: headers['x-source']?.toString() || 'api',
-    userId: headers['x-user-id']?.toString()
+  router.get('/contacts/:id', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    const contactId = req.params.id;
+
+    try {
+      const events = await eventStore.getEventsForAggregate('contact', contactId);
+      const state = projectContact(events);
+
+      if (!state) {
+        return res.status(404).json({ error: 'Contact not found' });
+      }
+
+      console.log(`[ContactFetched]`, { traceId: trace.traceId, spanId: trace.spanId, contactId });
+      return res.status(200).json(state);
+    } catch (err) {
+      console.error('[get-contact error]', err);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   });
 }
 
-router.get('/contacts/:id', async (req, res) => {
-  const trace = extractTraceFromHeaders(req.headers);
-  const contactId = req.params.id;
-
-  try {
-    const events = await getEventsForAggregate('contact', contactId);
-    const state = projectContact(events);
-
-    if (!state) {
-      return res.status(404).json({ error: 'Contact not found' });
-    }
-
-    console.log(`[ContactFetched]`, { traceId: trace.traceId, spanId: trace.spanId, contactId });
-    return res.status(200).json(state);
-  } catch (err) {
-    console.error('[get-contact error]', err);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-export default router;


### PR DESCRIPTION
## Summary
- implement `EventStore` interface and exported instance
- add `Slice` interface and create aggregate-level slice classes
- register HTTP handlers through injection instead of default routers
- wire new slices in `server.ts`

## Testing
- `npm test` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6856f38a8154832884515ad69df4bb27