### PR TITLE
Add realistic fields to CRM entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ src/
 - **server.ts** registers each aggregate as an Express router.
 - Inside `aggregates/` each aggregate is composed of slices implementing the command and event flow.
 
+### Entities
+
+The project models two core aggregates:
+
+- **Contact** — `contactId`, `name`, `email` and `phone`.
+- **Client** — `clientId`, `name` and `industry`.
+
 ## Event Store
 
 Events are persisted in **DynamoDB**. The helper `appendEvent` controls the aggregate version and verifies that no `undefined` values are present before writing:

--- a/src/aggregates/client/create-client/create-client.test.ts
+++ b/src/aggregates/client/create-client/create-client.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { handleCreateClient } from './index.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
+import { Industry } from '../value-objects/industry.js';
 
 const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
 
@@ -10,11 +11,13 @@ test('valid command produces event', () => {
   const cmd = {
     clientId: new ClientId('1'),
     name: new Name('ACME'),
+    industry: new Industry('Software'),
     trace
   };
   const res = handleCreateClient(cmd);
   assert.equal(res.ok, true);
   if (res.ok) {
     assert.equal(res.value.clientId, '1');
+    assert.equal(res.value.industry, 'Software');
   }
 });

--- a/src/aggregates/client/create-client/http.ts
+++ b/src/aggregates/client/create-client/http.ts
@@ -4,6 +4,7 @@ import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
+import { Industry } from '../value-objects/industry.js';
 
 export function registerCreateClientRoutes(router: Router, eventStore: EventStore) {
   function extractTraceFromHeaders(headers: Record<string, unknown>) {
@@ -22,6 +23,7 @@ export function registerCreateClientRoutes(router: Router, eventStore: EventStor
       cmd = {
         clientId: new ClientId(req.body.clientId),
         name: new Name(req.body.name),
+        industry: new Industry(req.body.industry),
         trace
       };
     } catch (err) {

--- a/src/aggregates/client/create-client/index.ts
+++ b/src/aggregates/client/create-client/index.ts
@@ -1,10 +1,12 @@
 import { TraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
+import { Industry } from '../value-objects/industry.js';
 
 export type CreateClientCommand = {
   clientId: ClientId;
   name: Name;
+  industry: Industry;
   trace: TraceContext;
 };
 
@@ -12,6 +14,7 @@ export type ClientCreatedEvent = {
   type: 'ClientCreated';
   clientId: string;
   name: string;
+  industry: string;
   trace: TraceContext;
   timestamp: string;
 };
@@ -25,6 +28,7 @@ export function handleCreateClient(
     type: 'ClientCreated',
     clientId: cmd.clientId.value,
     name: cmd.name.value,
+    industry: cmd.industry.value,
     trace: cmd.trace,
     timestamp: new Date().toISOString()
   };

--- a/src/aggregates/client/edit-client/edit-client.test.ts
+++ b/src/aggregates/client/edit-client/edit-client.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { handleEditClient } from './index.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
+import { Industry } from '../value-objects/industry.js';
 
 const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
 
@@ -12,11 +13,17 @@ test('fails when no updates provided', () => {
   assert.equal(res.ok, false);
 });
 
-test('updates name', () => {
-  const cmd = { clientId: new ClientId('1'), name: new Name('Globex'), trace };
+test('updates name and industry', () => {
+  const cmd = {
+    clientId: new ClientId('1'),
+    name: new Name('Globex'),
+    industry: new Industry('Finance'),
+    trace
+  };
   const res = handleEditClient(cmd);
   assert.equal(res.ok, true);
   if (res.ok) {
     assert.equal(res.value.name, 'Globex');
+    assert.equal(res.value.industry, 'Finance');
   }
 });

--- a/src/aggregates/client/edit-client/http.ts
+++ b/src/aggregates/client/edit-client/http.ts
@@ -4,6 +4,7 @@ import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
+import { Industry } from '../value-objects/industry.js';
 
 export function registerEditClientRoutes(router: Router, eventStore: EventStore) {
   function extractTraceFromHeaders(headers: Record<string, unknown>) {
@@ -22,6 +23,8 @@ export function registerEditClientRoutes(router: Router, eventStore: EventStore)
       cmd = {
         clientId: new ClientId(req.params.id),
         name: req.body.name ? new Name(req.body.name) : undefined,
+        industry:
+          req.body.industry !== undefined ? new Industry(req.body.industry) : undefined,
         trace
       };
     } catch (err) {

--- a/src/aggregates/client/edit-client/index.ts
+++ b/src/aggregates/client/edit-client/index.ts
@@ -1,10 +1,12 @@
 import { TraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
+import { Industry } from '../value-objects/industry.js';
 
 export type EditClientCommand = {
   clientId: ClientId;
   name?: Name;
+  industry?: Industry;
   trace: TraceContext;
 };
 
@@ -12,6 +14,7 @@ export type ClientEditedEvent = {
   type: 'ClientEdited';
   clientId: string;
   name?: string;
+  industry?: string;
   trace: TraceContext;
   timestamp: string;
 };
@@ -19,7 +22,7 @@ export type ClientEditedEvent = {
 type Result<T> = { ok: true; value: T } | { ok: false; error: string };
 
 function validate(cmd: EditClientCommand): Result<EditClientCommand> {
-  if (!cmd.name) {
+  if (!cmd.name && !cmd.industry) {
     return { ok: false, error: 'nothing to update' };
   }
 
@@ -36,6 +39,7 @@ export function handleEditClient(
     type: 'ClientEdited',
     clientId: cmd.clientId.value,
     name: cmd.name?.value,
+    industry: cmd.industry?.value,
     trace: cmd.trace,
     timestamp: new Date().toISOString()
   };

--- a/src/aggregates/client/project-client/index.ts
+++ b/src/aggregates/client/project-client/index.ts
@@ -1,6 +1,7 @@
 export type ClientState = {
   clientId: string;
   name?: string;
+  industry?: string;
   contactIds: string[];
   version: number;
 };
@@ -19,11 +20,13 @@ export function projectClient(events: any[]): ClientState | null {
       case 'ClientCreated':
         state.clientId = event.clientId;
         state.name = event.name;
+        state.industry = event.industry;
         state.version += 1;
         break;
 
       case 'ClientEdited':
         if (event.name) state.name = event.name;
+        if (event.industry) state.industry = event.industry;
         state.version += 1;
         break;
 

--- a/src/aggregates/client/project-client/project-client.test.ts
+++ b/src/aggregates/client/project-client/project-client.test.ts
@@ -8,6 +8,7 @@ const created = {
   type: 'ClientCreated',
   clientId: '1',
   name: 'ACME',
+  industry: 'Software',
   trace,
   timestamp: new Date().toISOString()
 };
@@ -27,5 +28,6 @@ test('returns null for empty events', () => {
 test('projects latest state', () => {
   const state = projectClient([created, linked]);
   assert.equal(state?.contactIds.length, 1);
+  assert.equal(state?.industry, 'Software');
   assert.equal(state?.version, 2);
 });

--- a/src/aggregates/client/value-objects/industry.ts
+++ b/src/aggregates/client/value-objects/industry.ts
@@ -1,0 +1,9 @@
+export class Industry {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim().length < 2) {
+      throw new Error('industry must be at least 2 characters');
+    }
+    this.value = value;
+  }
+}

--- a/src/aggregates/contact/create-contact/create-contact.test.ts
+++ b/src/aggregates/contact/create-contact/create-contact.test.ts
@@ -4,6 +4,7 @@ import { handleCreateContact } from './index.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
+import { Phone } from '../value-objects/phone.js';
 
 const baseTrace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
 
@@ -12,6 +13,7 @@ test('valid command produces event', () => {
     contactId: new ContactId('1'),
     name: new Name('John'),
     email: new Mail('john@example.com'),
+    phone: new Phone('123456789'),
     trace: baseTrace
   };
   const res = handleCreateContact(cmd);

--- a/src/aggregates/contact/create-contact/http.ts
+++ b/src/aggregates/contact/create-contact/http.ts
@@ -5,6 +5,7 @@ import { createTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
+import { Phone } from '../value-objects/phone.js';
 
 export function registerCreateContactRoutes(router: Router, eventStore: EventStore) {
   function extractTraceFromHeaders(headers: Record<string, unknown>) {
@@ -24,6 +25,7 @@ export function registerCreateContactRoutes(router: Router, eventStore: EventSto
         contactId: new ContactId(req.body.contactId),
         name: new Name(req.body.name),
         email: new Mail(req.body.email),
+        phone: new Phone(req.body.phone),
         trace
       };
     } catch (err) {

--- a/src/aggregates/contact/create-contact/index.ts
+++ b/src/aggregates/contact/create-contact/index.ts
@@ -2,11 +2,13 @@ import { TraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
+import { Phone } from '../value-objects/phone.js';
 
 export type CreateContactCommand = {
   contactId: ContactId;
   name: Name;
   email: Mail;
+  phone: Phone;
   trace: TraceContext;
 };
 
@@ -15,6 +17,7 @@ export type ContactCreatedEvent = {
   contactId: string;
   name: string;
   email: string;
+  phone: string;
   trace: TraceContext;
   timestamp: string;
 };
@@ -29,6 +32,7 @@ export function handleCreateContact(
     contactId: cmd.contactId.value,
     name: cmd.name.value,
     email: cmd.email.value,
+    phone: cmd.phone.value,
     trace: cmd.trace,
     timestamp: new Date().toISOString(),
   };

--- a/src/aggregates/contact/edit-contact/edit-contact.test.ts
+++ b/src/aggregates/contact/edit-contact/edit-contact.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { handleEditContact } from './index.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
+import { Phone } from '../value-objects/phone.js';
 
 const baseTrace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
 
@@ -12,11 +13,17 @@ test('fails when no updates provided', () => {
   assert.equal(res.ok, false);
 });
 
-test('updates name', () => {
-  const cmd = { contactId: new ContactId('1'), name: new Name('Jane'), trace: baseTrace };
+test('updates name and phone', () => {
+  const cmd = {
+    contactId: new ContactId('1'),
+    name: new Name('Jane'),
+    phone: new Phone('987654321'),
+    trace: baseTrace
+  };
   const res = handleEditContact(cmd);
   assert.equal(res.ok, true);
   if (res.ok) {
     assert.equal(res.value.name, 'Jane');
+    assert.equal(res.value.phone, '987654321');
   }
 });

--- a/src/aggregates/contact/edit-contact/http.ts
+++ b/src/aggregates/contact/edit-contact/http.ts
@@ -5,6 +5,7 @@ import { createTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
+import { Phone } from '../value-objects/phone.js';
 
 export function registerEditContactRoutes(router: Router, eventStore: EventStore) {
   function extractTraceFromHeaders(headers: Record<string, unknown>) {
@@ -24,6 +25,7 @@ export function registerEditContactRoutes(router: Router, eventStore: EventStore
         contactId: new ContactId(req.params.id),
         name: req.body.name !== undefined ? new Name(req.body.name) : undefined,
         email: req.body.email !== undefined ? new Mail(req.body.email) : undefined,
+        phone: req.body.phone !== undefined ? new Phone(req.body.phone) : undefined,
         trace
       };
     } catch (err) {

--- a/src/aggregates/contact/edit-contact/index.ts
+++ b/src/aggregates/contact/edit-contact/index.ts
@@ -4,11 +4,13 @@ import { TraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
+import { Phone } from '../value-objects/phone.js';
 
 export type EditContactCommand = {
   contactId: ContactId;
   name?: Name;
   email?: Mail;
+  phone?: Phone;
   trace: TraceContext;
 };
 
@@ -17,6 +19,7 @@ export type ContactEditedEvent = {
   contactId: string;
   name?: string;
   email?: string;
+  phone?: string;
   trace: TraceContext;
   timestamp: string;
 };
@@ -24,7 +27,7 @@ export type ContactEditedEvent = {
 type Result<T> = { ok: true; value: T } | { ok: false; error: string };
 
 function validate(cmd: EditContactCommand): Result<EditContactCommand> {
-  if (!cmd.name && !cmd.email) {
+  if (!cmd.name && !cmd.email && !cmd.phone) {
     return { ok: false, error: 'nothing to update' };
   }
 
@@ -42,6 +45,7 @@ export function handleEditContact(
     contactId: cmd.contactId.value,
     name: cmd.name?.value,
     email: cmd.email?.value,
+    phone: cmd.phone?.value,
     trace: cmd.trace,
     timestamp: new Date().toISOString()
   };

--- a/src/aggregates/contact/project-contact/index.ts
+++ b/src/aggregates/contact/project-contact/index.ts
@@ -4,6 +4,7 @@ type ContactState = {
   contactId: string;
   name?: string;
   email?: string;
+  phone?: string;
   version: number;
 };
 
@@ -21,12 +22,14 @@ export function projectContact(events: any[]): ContactState | null {
         state.contactId = event.contactId;
         state.name = event.name;
         state.email = event.email;
+        state.phone = event.phone;
         state.version += 1;
         break;
 
       case 'ContactEdited':
         if (event.name) state.name = event.name;
         if (event.email) state.email = event.email;
+        if (event.phone) state.phone = event.phone;
         state.version += 1;
         break;
     }

--- a/src/aggregates/contact/project-contact/project-contact.test.ts
+++ b/src/aggregates/contact/project-contact/project-contact.test.ts
@@ -9,6 +9,7 @@ const created = {
   contactId: '1',
   name: 'John',
   email: 'john@example.com',
+  phone: '123456789',
   trace,
   timestamp: new Date().toISOString()
 };
@@ -17,6 +18,7 @@ const edited = {
   type: 'ContactEdited',
   contactId: '1',
   name: 'Jane',
+  phone: '987654321',
   trace,
   timestamp: new Date().toISOString()
 };
@@ -28,5 +30,6 @@ test('returns null for empty events', () => {
 test('projects latest state', () => {
   const state = projectContact([created, edited]);
   assert.equal(state?.name, 'Jane');
+  assert.equal(state?.phone, '987654321');
   assert.equal(state?.version, 2);
 });

--- a/src/aggregates/contact/value-objects/phone.ts
+++ b/src/aggregates/contact/value-objects/phone.ts
@@ -1,0 +1,9 @@
+export class Phone {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim().length < 7) {
+      throw new Error('invalid phone');
+    }
+    this.value = value;
+  }
+}


### PR DESCRIPTION
## Summary
- expand `Contact` with `phone`
- expand `Client` with `industry`
- handle the new fields in commands, events, routes and projections
- provide value objects `Phone` and `Industry`
- update tests and README with updated entity definitions

## Testing
- `npm run test` *(fails: cannot find modules due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857bd0e98e48328a9060fa1d1386af0