### PR TITLE
Add HTTP data seeding script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite-node src/server.ts",
-    "test": "tsc --outDir dist && node --test dist/**/*.test.js"
+    "test": "tsc --outDir dist && node --test dist/**/*.test.js",
+    "seed": "vite-node src/scripts/generate-data.ts"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.540.0",

--- a/src/scripts/generate-data.ts
+++ b/src/scripts/generate-data.ts
@@ -1,0 +1,100 @@
+const count = parseInt(process.argv[2] || '0', 10) || 1;
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000/api';
+
+const firstNames = [
+  'Carlos',
+  'Mar\u00eda',
+  'Juan',
+  'Ana',
+  'Luis',
+  'Laura',
+  'Miguel',
+  'Sof\u00eda',
+  'Pedro',
+  'Luc\u00eda'
+];
+
+const lastNames = [
+  'Garc\u00eda',
+  'L\u00f3pez',
+  'Mart\u00ednez',
+  'Rodr\u00edguez',
+  'S\u00e1nchez',
+  'P\u00e9rez',
+  'G\u00f3mez',
+  'Fern\u00e1ndez',
+  'D\u00edaz',
+  'Torres'
+];
+
+const industries = [
+  'Technology',
+  'Finance',
+  'Healthcare',
+  'Education',
+  'Retail',
+  'Hospitality'
+];
+
+function rand<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randName(): string {
+  return `${rand(firstNames)} ${rand(lastNames)}`;
+}
+
+function randEmail(name: string): string {
+  const slug = name.toLowerCase().replace(/\s+/g, '.');
+  return `${slug}@example.com`;
+}
+
+function randPhone(): string {
+  return String(Math.floor(600000000 + Math.random() * 100000000));
+}
+
+function randomId(): string {
+  return (
+    Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)
+  );
+}
+
+async function createClient(name: string) {
+  const body = {
+    clientId: randomId(),
+    name,
+    industry: rand(industries)
+  };
+  await fetch(`${BASE_URL}/clients`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+async function createContact(name: string) {
+  const body = {
+    contactId: randomId(),
+    name,
+    email: randEmail(name),
+    phone: randPhone()
+  };
+  await fetch(`${BASE_URL}/contacts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+async function main() {
+  for (let i = 0; i < count; i++) {
+    await createClient(randName());
+    await createContact(randName());
+  }
+  console.log(`Generated ${count} clients and contacts`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to generate dummy clients and contacts via HTTP
- expose `npm run seed` to run the generator

## Testing
- `npm test` *(fails: cannot find module `node:test` and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857c0b49ee88328ab2c7c0f40752a5c