### PR TITLE
Add client link to cases and expand seed data

### DIFF
--- a/src/aggregates/case/create-case/create-case.test.ts
+++ b/src/aggregates/case/create-case/create-case.test.ts
@@ -3,12 +3,14 @@ import assert from 'node:assert/strict';
 import { handleCreateCase } from './index.js';
 import { CaseId } from '../value-objects/case-id.js';
 import { Description } from '../value-objects/description.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
 
 const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
 
 test('valid command produces event', () => {
   const cmd = {
     caseId: new CaseId('1'),
+    clientId: new ClientId('c1'),
     openedAt: '2024-01-01',
     description: new Description('Support request'),
     trace
@@ -17,6 +19,7 @@ test('valid command produces event', () => {
   assert.equal(res.ok, true);
   if (res.ok) {
     assert.equal(res.value.caseId, '1');
+    assert.equal(res.value.clientId, 'c1');
     assert.equal(res.value.openedAt, '2024-01-01');
   }
 });

--- a/src/aggregates/case/create-case/http.ts
+++ b/src/aggregates/case/create-case/http.ts
@@ -4,6 +4,7 @@ import type { EventStore } from '../../../shared/event-store.js';
 import { createTraceContext } from '../../../shared/trace.js';
 import { CaseId } from '../value-objects/case-id.js';
 import { Description } from '../value-objects/description.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
 
 export function registerCreateCaseRoutes(router: Router, eventStore: EventStore) {
   function extractTraceFromHeaders(headers: Record<string, unknown>) {
@@ -21,6 +22,7 @@ export function registerCreateCaseRoutes(router: Router, eventStore: EventStore)
     try {
       cmd = {
         caseId: new CaseId(req.body.caseId),
+        clientId: new ClientId(req.body.clientId),
         openedAt: req.body.openedAt,
         description: new Description(req.body.description),
         trace
@@ -39,7 +41,8 @@ export function registerCreateCaseRoutes(router: Router, eventStore: EventStore)
       console.log(`[CaseCreated]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        caseId: result.value.caseId
+        caseId: result.value.caseId,
+        clientId: result.value.clientId
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/case/create-case/index.ts
+++ b/src/aggregates/case/create-case/index.ts
@@ -1,9 +1,11 @@
 import { TraceContext } from '../../../shared/trace.js';
 import { CaseId } from '../value-objects/case-id.js';
 import { Description } from '../value-objects/description.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
 
 export type CreateCaseCommand = {
   caseId: CaseId;
+  clientId: ClientId;
   openedAt: string;
   description: Description;
   trace: TraceContext;
@@ -12,6 +14,7 @@ export type CreateCaseCommand = {
 export type CaseCreatedEvent = {
   type: 'CaseCreated';
   caseId: string;
+  clientId: string;
   openedAt: string;
   description: string;
   trace: TraceContext;
@@ -24,6 +27,7 @@ export function handleCreateCase(cmd: CreateCaseCommand): Result<CaseCreatedEven
   const event: CaseCreatedEvent = {
     type: 'CaseCreated',
     caseId: cmd.caseId.value,
+    clientId: cmd.clientId.value,
     openedAt: cmd.openedAt,
     description: cmd.description.value,
     trace: cmd.trace,

--- a/src/aggregates/case/project-case/index.ts
+++ b/src/aggregates/case/project-case/index.ts
@@ -1,5 +1,6 @@
 export type CaseState = {
   caseId: string;
+  clientId?: string;
   description?: string;
   openedAt?: string;
   closedAt?: string;
@@ -12,6 +13,7 @@ export function projectCase(events: any[]): CaseState | null {
 
   const state: CaseState = {
     caseId: '',
+    clientId: undefined,
     interactions: [],
     version: 0
   };
@@ -20,6 +22,7 @@ export function projectCase(events: any[]): CaseState | null {
     switch (event.type) {
       case 'CaseCreated':
         state.caseId = event.caseId;
+        state.clientId = event.clientId;
         state.description = event.description;
         state.openedAt = event.openedAt;
         state.version += 1;

--- a/src/aggregates/case/project-case/project-case.test.ts
+++ b/src/aggregates/case/project-case/project-case.test.ts
@@ -7,6 +7,7 @@ const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() }
 const created = {
   type: 'CaseCreated',
   caseId: '1',
+  clientId: 'c1',
   openedAt: '2024-01-01',
   description: 'Support request',
   trace,
@@ -37,6 +38,7 @@ test('returns null for empty events', () => {
 test('projects latest state', () => {
   const state = projectCase([created, interaction, closed]);
   assert.equal(state?.interactions.length, 1);
+  assert.equal(state?.clientId, 'c1');
   assert.equal(state?.closedAt, '2024-01-03');
   assert.equal(state?.version, 3);
 });

--- a/src/scripts/generate-data.ts
+++ b/src/scripts/generate-data.ts
@@ -96,13 +96,61 @@ async function linkContact(clientId: string, contactId: string) {
   });
 }
 
+async function createCase(clientId: string): Promise<string> {
+  const body = {
+    caseId: randomId(),
+    clientId,
+    openedAt: new Date().toISOString(),
+    description: `Issue ${randomId().slice(0, 5)}`
+  };
+  await fetch(`${BASE_URL}/cases`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  return body.caseId;
+}
+
+async function addInteraction(caseId: string) {
+  const body = {
+    interactionDate: new Date().toISOString(),
+    description: `Note ${randomId().slice(0, 5)}`
+  };
+  await fetch(`${BASE_URL}/cases/${caseId}/interactions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+async function closeCase(caseId: string) {
+  const body = { closedAt: new Date().toISOString() };
+  await fetch(`${BASE_URL}/cases/${caseId}/close`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
 async function main() {
   for (let i = 0; i < count; i++) {
     const clientId = await createClient(randName());
     const contactId = await createContact(randName());
     await linkContact(clientId, contactId);
+
+    const caseCount = Math.floor(Math.random() * 6); // 0-5
+    for (let c = 0; c < caseCount; c++) {
+      const caseId = await createCase(clientId);
+      const interactions = 1 + Math.floor(Math.random() * 10);
+      for (let j = 0; j < interactions; j++) {
+        await addInteraction(caseId);
+      }
+      if (Math.random() < 0.8) {
+        await closeCase(caseId);
+      }
+    }
   }
-  console.log(`Generated ${count} clients and contacts`);
+  console.log(`Generated ${count} clients with related data`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- associate cases with clients via `clientId`
- expose `clientId` in case projection
- adjust tests for the new property
- generate random cases and interactions in the seed script

## Testing
- `npm test` *(fails: Cannot find module 'express' or '@aws-sdk/...')*

------
https://chatgpt.com/codex/tasks/task_e_6857c574f9e8832892bd07e7db5002e6