### PR TITLE
Add open cases slice

### DIFF
--- a/src/aggregates/case/index.ts
+++ b/src/aggregates/case/index.ts
@@ -5,6 +5,7 @@ import { registerCreateCaseRoutes } from './create-case/http.js';
 import { registerAddInteractionRoutes } from './add-interaction/http.js';
 import { registerCloseCaseRoutes } from './close-case/http.js';
 import { registerProjectCaseRoutes } from './project-case/http.js';
+import { registerOpenCasesRoutes } from './open-cases/http.js';
 
 export class CaseAggregate implements Aggregate {
   constructor(router: Router, eventStore: EventStore) {
@@ -12,5 +13,6 @@ export class CaseAggregate implements Aggregate {
     registerAddInteractionRoutes(router, eventStore);
     registerCloseCaseRoutes(router, eventStore);
     registerProjectCaseRoutes(router, eventStore);
+    registerOpenCasesRoutes(router, eventStore);
   }
 }

--- a/src/aggregates/case/open-cases/http.ts
+++ b/src/aggregates/case/open-cases/http.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { projectOpenCases } from './index.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import type { EventStore } from '../../../shared/event-store.js';
+
+export function registerOpenCasesRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
+
+  router.get('/cases/open', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    const clientId = req.query.clientId?.toString();
+
+    try {
+      const events = await eventStore.getEventsByPrefix('case#');
+      const cases = projectOpenCases(events, clientId);
+      console.log(`[OpenCasesFetched]`, { traceId: trace.traceId, spanId: trace.spanId, count: cases.length, clientId });
+      return res.status(200).json(cases);
+    } catch (err) {
+      console.error('[get-open-cases error]', err);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+}

--- a/src/aggregates/case/open-cases/index.ts
+++ b/src/aggregates/case/open-cases/index.ts
@@ -1,0 +1,23 @@
+import { projectCase, CaseState } from '../project-case/index.js';
+
+export function projectOpenCases(events: any[], clientId?: string): CaseState[] {
+  const byCase: Record<string, any[]> = {};
+
+  for (const evt of events) {
+    const id = evt.caseId;
+    if (!id) continue;
+    if (!byCase[id]) byCase[id] = [];
+    byCase[id].push(evt);
+  }
+
+  const result: CaseState[] = [];
+  for (const evts of Object.values(byCase)) {
+    evts.sort((a, b) => (a.SK || '').localeCompare(b.SK || ''));
+    const state = projectCase(evts);
+    if (state && !state.closedAt && (!clientId || state.clientId === clientId)) {
+      result.push(state);
+    }
+  }
+
+  return result;
+}

--- a/src/aggregates/case/open-cases/open-cases.test.ts
+++ b/src/aggregates/case/open-cases/open-cases.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { projectOpenCases } from './index.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+const case1Created = {
+  type: 'CaseCreated',
+  caseId: '1',
+  clientId: 'c1',
+  openedAt: '2024-01-01',
+  description: 'Issue',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+const case1Closed = {
+  type: 'CaseClosed',
+  caseId: '1',
+  closedAt: '2024-01-02',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+const case2Created = {
+  type: 'CaseCreated',
+  caseId: '2',
+  clientId: 'c2',
+  openedAt: '2024-01-03',
+  description: 'Another',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+test('filters open cases', () => {
+  const result = projectOpenCases([case1Created, case1Closed, case2Created]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].caseId, '2');
+});
+
+test('filters by clientId', () => {
+  const result = projectOpenCases([case1Created, case2Created], 'c1');
+  assert.equal(result.length, 1);
+  assert.equal(result[0].clientId, 'c1');
+});

--- a/src/shared/event-store.ts
+++ b/src/shared/event-store.ts
@@ -2,6 +2,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   QueryCommand,
+  ScanCommand,
   TransactWriteCommand
 } from "@aws-sdk/lib-dynamodb";
 
@@ -60,6 +61,19 @@ export async function getEventsForAggregate(
     })
   );
 
+  return result.Items || [];
+}
+
+export async function getEventsByPrefix(prefix: string): Promise<any[]> {
+  const result = await docClient.send(
+    new ScanCommand({
+      TableName: "EventStore",
+      FilterExpression: "begins_with(PK, :pk)",
+      ExpressionAttributeValues: {
+        ":pk": prefix
+      }
+    })
+  );
   return result.Items || [];
 }
 
@@ -132,11 +146,13 @@ export async function appendEvent(
 export interface EventStore {
   appendEvent: typeof appendEvent;
   getEventsForAggregate: typeof getEventsForAggregate;
+  getEventsByPrefix: typeof getEventsByPrefix;
   subscribe: typeof subscribe;
 }
 
 export const eventStore: EventStore = {
   appendEvent,
   getEventsForAggregate,
+  getEventsByPrefix,
   subscribe
 };


### PR DESCRIPTION
## Summary
- add `getEventsByPrefix` to the event store
- implement open cases projection and route
- register the new route in the case aggregate
- cover open case projection with tests

## Testing
- `npm test` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6857c747c3d48328adfef6900c4a5091