### PR TITLE
Include request duration in logs

### DIFF
--- a/src/aggregates/case/add-interaction/http.ts
+++ b/src/aggregates/case/add-interaction/http.ts
@@ -17,6 +17,7 @@ export function registerAddInteractionRoutes(router: Router, eventStore: EventSt
 
   router.post('/cases/:id/interactions', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -37,10 +38,12 @@ export function registerAddInteractionRoutes(router: Router, eventStore: EventSt
     try {
       const version = 2; // TODO: real version
       await eventStore.appendEvent(result.value, 'case', cmd.caseId.value, version);
+      const durationMs = Date.now() - startTime;
       console.log(`[InteractionAdded]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        caseId: cmd.caseId.value
+        caseId: cmd.caseId.value,
+        durationMs
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/case/close-case/http.ts
+++ b/src/aggregates/case/close-case/http.ts
@@ -16,6 +16,7 @@ export function registerCloseCaseRoutes(router: Router, eventStore: EventStore) 
 
   router.post('/cases/:id/close', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -35,10 +36,12 @@ export function registerCloseCaseRoutes(router: Router, eventStore: EventStore) 
     try {
       const version = 3; // TODO: real version
       await eventStore.appendEvent(result.value, 'case', cmd.caseId.value, version);
+      const durationMs = Date.now() - startTime;
       console.log(`[CaseClosed]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        caseId: cmd.caseId.value
+        caseId: cmd.caseId.value,
+        durationMs
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/case/create-case/http.ts
+++ b/src/aggregates/case/create-case/http.ts
@@ -18,6 +18,7 @@ export function registerCreateCaseRoutes(router: Router, eventStore: EventStore)
 
   router.post('/cases', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -38,11 +39,13 @@ export function registerCreateCaseRoutes(router: Router, eventStore: EventStore)
 
     try {
       await eventStore.appendEvent(result.value, 'case', result.value.caseId, 1);
+      const durationMs = Date.now() - startTime;
       console.log(`[CaseCreated]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         caseId: result.value.caseId,
-        clientId: result.value.clientId
+        clientId: result.value.clientId,
+        durationMs
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/case/open-cases/http.ts
+++ b/src/aggregates/case/open-cases/http.ts
@@ -16,11 +16,13 @@ export function registerOpenCasesRoutes(router: Router, eventStore: EventStore) 
   router.get('/cases/open', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
     const clientId = req.query.clientId?.toString();
+    const startTime = Date.now();
 
     try {
       const events = await eventStore.getEventsByPrefix('case#');
       const cases = projectOpenCases(events, clientId);
-      console.log(`[OpenCasesFetched]`, { traceId: trace.traceId, spanId: trace.spanId, count: cases.length, clientId });
+      const durationMs = Date.now() - startTime;
+      console.log(`[OpenCasesFetched]`, { traceId: trace.traceId, spanId: trace.spanId, count: cases.length, clientId, durationMs });
       return res.status(200).json(cases);
     } catch (err) {
       console.error('[get-open-cases error]', err);

--- a/src/aggregates/case/project-case/http.ts
+++ b/src/aggregates/case/project-case/http.ts
@@ -16,6 +16,7 @@ export function registerProjectCaseRoutes(router: Router, eventStore: EventStore
   router.get('/cases/:id', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
     const caseId = req.params.id;
+    const startTime = Date.now();
 
     try {
       const events = await eventStore.getEventsForAggregate('case', caseId);
@@ -25,7 +26,8 @@ export function registerProjectCaseRoutes(router: Router, eventStore: EventStore
         return res.status(404).json({ error: 'Case not found' });
       }
 
-      console.log(`[CaseFetched]`, { traceId: trace.traceId, spanId: trace.spanId, caseId });
+      const durationMs = Date.now() - startTime;
+      console.log(`[CaseFetched]`, { traceId: trace.traceId, spanId: trace.spanId, caseId, durationMs });
       return res.status(200).json(state);
     } catch (err) {
       console.error('[get-case error]', err);

--- a/src/aggregates/client/create-client/http.ts
+++ b/src/aggregates/client/create-client/http.ts
@@ -18,6 +18,7 @@ export function registerCreateClientRoutes(router: Router, eventStore: EventStor
 
   router.post('/clients', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -37,10 +38,12 @@ export function registerCreateClientRoutes(router: Router, eventStore: EventStor
 
     try {
       await eventStore.appendEvent(result.value, 'client', result.value.clientId, 1);
+      const durationMs = Date.now() - startTime;
       console.log(`[ClientCreated]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        clientId: result.value.clientId
+        clientId: result.value.clientId,
+        durationMs
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/client/edit-client/http.ts
+++ b/src/aggregates/client/edit-client/http.ts
@@ -18,6 +18,7 @@ export function registerEditClientRoutes(router: Router, eventStore: EventStore)
 
   router.put('/clients/:id', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -38,10 +39,12 @@ export function registerEditClientRoutes(router: Router, eventStore: EventStore)
 
     try {
       await eventStore.appendEvent(result.value, 'client', result.value.clientId, 2);
+      const durationMs = Date.now() - startTime;
       console.log(`[ClientEdited]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        clientId: result.value.clientId
+        clientId: result.value.clientId,
+        durationMs
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/client/link-contact/http.ts
+++ b/src/aggregates/client/link-contact/http.ts
@@ -17,6 +17,7 @@ export function registerLinkContactRoutes(router: Router, eventStore: EventStore
 
   router.post('/clients/:id/contacts', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -35,11 +36,13 @@ export function registerLinkContactRoutes(router: Router, eventStore: EventStore
 
     try {
       await eventStore.appendEvent(result.value, 'client', result.value.clientId, 3);
+      const durationMs = Date.now() - startTime;
       console.log(`[ContactLinked]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         clientId: result.value.clientId,
-        contactId: result.value.contactId
+        contactId: result.value.contactId,
+        durationMs
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/client/project-client/http.ts
+++ b/src/aggregates/client/project-client/http.ts
@@ -16,6 +16,7 @@ export function registerProjectClientRoutes(router: Router, eventStore: EventSto
   router.get('/clients/:id', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
     const clientId = req.params.id;
+    const startTime = Date.now();
 
     try {
       const events = await eventStore.getEventsForAggregate('client', clientId);
@@ -25,7 +26,8 @@ export function registerProjectClientRoutes(router: Router, eventStore: EventSto
         return res.status(404).json({ error: 'Client not found' });
       }
 
-      console.log(`[ClientFetched]`, { traceId: trace.traceId, spanId: trace.spanId, clientId });
+      const durationMs = Date.now() - startTime;
+      console.log(`[ClientFetched]`, { traceId: trace.traceId, spanId: trace.spanId, clientId, durationMs });
       return res.status(200).json(state);
     } catch (err) {
       console.error('[get-client error]', err);

--- a/src/aggregates/client/unlink-contact/http.ts
+++ b/src/aggregates/client/unlink-contact/http.ts
@@ -17,6 +17,7 @@ export function registerUnlinkContactRoutes(router: Router, eventStore: EventSto
 
   router.delete('/clients/:id/contacts/:contactId', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -35,11 +36,13 @@ export function registerUnlinkContactRoutes(router: Router, eventStore: EventSto
 
     try {
       await eventStore.appendEvent(result.value, 'client', result.value.clientId, 4);
+      const durationMs = Date.now() - startTime;
       console.log(`[ContactUnlinked]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         clientId: result.value.clientId,
-        contactId: result.value.contactId
+        contactId: result.value.contactId,
+        durationMs
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/contact/create-contact/http.ts
+++ b/src/aggregates/contact/create-contact/http.ts
@@ -19,6 +19,7 @@ export function registerCreateContactRoutes(router: Router, eventStore: EventSto
 
   router.post('/contacts', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -39,10 +40,12 @@ export function registerCreateContactRoutes(router: Router, eventStore: EventSto
 
     try {
       await eventStore.appendEvent(result.value, 'contact', result.value.contactId, 1);
+      const durationMs = Date.now() - startTime;
       console.log(`[ContactCreated]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        contactId: result.value.contactId
+        contactId: result.value.contactId,
+        durationMs
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/contact/delete-contact/http.ts
+++ b/src/aggregates/contact/delete-contact/http.ts
@@ -17,6 +17,7 @@ export function registerDeleteContactRoutes(router: Router, eventStore: EventSto
 
   router.delete('/contacts/:id', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     const cascade = req.query.cascade === 'true';
     let cmd;
     try {
@@ -38,10 +39,12 @@ export function registerDeleteContactRoutes(router: Router, eventStore: EventSto
     try {
       const version = 3; // TODO: real version
       await eventStore.appendEvent(result.value, 'contact', cmd.contactId.value, version);
+      const durationMs = Date.now() - startTime;
       console.log(`[ContactDeleted]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        contactId: cmd.contactId.value
+        contactId: cmd.contactId.value,
+        durationMs
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/contact/edit-contact/http.ts
+++ b/src/aggregates/contact/edit-contact/http.ts
@@ -19,6 +19,7 @@ export function registerEditContactRoutes(router: Router, eventStore: EventStore
 
   router.put('/contacts/:id', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
     let cmd;
     try {
       cmd = {
@@ -39,10 +40,12 @@ export function registerEditContactRoutes(router: Router, eventStore: EventStore
     try {
       const version = 2; // TODO: real version
       await eventStore.appendEvent(result.value, 'contact', cmd.contactId.value, version);
+      const durationMs = Date.now() - startTime;
       console.log(`[ContactEdited]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
-        contactId: cmd.contactId.value
+        contactId: cmd.contactId.value,
+        durationMs
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/contact/project-contact/http.ts
+++ b/src/aggregates/contact/project-contact/http.ts
@@ -17,6 +17,7 @@ export function registerProjectContactRoutes(router: Router, eventStore: EventSt
   router.get('/contacts/:id', async (req, res) => {
     const trace = extractTraceFromHeaders(req.headers);
     const contactId = req.params.id;
+    const startTime = Date.now();
 
     try {
       const events = await eventStore.getEventsForAggregate('contact', contactId);
@@ -26,7 +27,8 @@ export function registerProjectContactRoutes(router: Router, eventStore: EventSt
         return res.status(404).json({ error: 'Contact not found' });
       }
 
-      console.log(`[ContactFetched]`, { traceId: trace.traceId, spanId: trace.spanId, contactId });
+      const durationMs = Date.now() - startTime;
+      console.log(`[ContactFetched]`, { traceId: trace.traceId, spanId: trace.spanId, contactId, durationMs });
       return res.status(200).json(state);
     } catch (err) {
       console.error('[get-contact error]', err);


### PR DESCRIPTION
## Summary
- log the time taken to process HTTP requests across all routes

## Testing
- `npm test` *(fails: Cannot find module 'express', missing types for node)*

------
https://chatgpt.com/codex/tasks/task_e_6857d397ce5883289cf86d24840d192f