### PR TITLE
Add PK and SK to event logs

### DIFF
--- a/src/aggregates/case/add-interaction/http.ts
+++ b/src/aggregates/case/add-interaction/http.ts
@@ -37,13 +37,17 @@ export function registerAddInteractionRoutes(router: Router, eventStore: EventSt
 
     try {
       const version = 2; // TODO: real version
+      const pk = `case#${cmd.caseId.value}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
       await eventStore.appendEvent(result.value, 'case', cmd.caseId.value, version);
       const durationMs = Date.now() - startTime;
       console.log(`[InteractionAdded]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         caseId: cmd.caseId.value,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/case/close-case/http.ts
+++ b/src/aggregates/case/close-case/http.ts
@@ -35,13 +35,17 @@ export function registerCloseCaseRoutes(router: Router, eventStore: EventStore) 
 
     try {
       const version = 3; // TODO: real version
+      const pk = `case#${cmd.caseId.value}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
       await eventStore.appendEvent(result.value, 'case', cmd.caseId.value, version);
       const durationMs = Date.now() - startTime;
       console.log(`[CaseClosed]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         caseId: cmd.caseId.value,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/case/create-case/http.ts
+++ b/src/aggregates/case/create-case/http.ts
@@ -38,14 +38,19 @@ export function registerCreateCaseRoutes(router: Router, eventStore: EventStore)
     if (!result.ok) return res.status(400).json({ error: result.error });
 
     try {
-      await eventStore.appendEvent(result.value, 'case', result.value.caseId, 1);
+      const version = 1;
+      const pk = `case#${result.value.caseId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'case', result.value.caseId, version);
       const durationMs = Date.now() - startTime;
       console.log(`[CaseCreated]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         caseId: result.value.caseId,
         clientId: result.value.clientId,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/client/create-client/http.ts
+++ b/src/aggregates/client/create-client/http.ts
@@ -37,13 +37,18 @@ export function registerCreateClientRoutes(router: Router, eventStore: EventStor
     if (!result.ok) return res.status(400).json({ error: result.error });
 
     try {
-      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 1);
+      const version = 1;
+      const pk = `client#${result.value.clientId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, version);
       const durationMs = Date.now() - startTime;
       console.log(`[ClientCreated]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         clientId: result.value.clientId,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/client/edit-client/http.ts
+++ b/src/aggregates/client/edit-client/http.ts
@@ -38,13 +38,18 @@ export function registerEditClientRoutes(router: Router, eventStore: EventStore)
     if (!result.ok) return res.status(400).json({ error: result.error });
 
     try {
-      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 2);
+      const version = 2;
+      const pk = `client#${result.value.clientId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, version);
       const durationMs = Date.now() - startTime;
       console.log(`[ClientEdited]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         clientId: result.value.clientId,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/client/link-contact/http.ts
+++ b/src/aggregates/client/link-contact/http.ts
@@ -35,14 +35,19 @@ export function registerLinkContactRoutes(router: Router, eventStore: EventStore
     if (!result.ok) return res.status(400).json({ error: result.error });
 
     try {
-      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 3);
+      const version = 3;
+      const pk = `client#${result.value.clientId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, version);
       const durationMs = Date.now() - startTime;
       console.log(`[ContactLinked]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         clientId: result.value.clientId,
         contactId: result.value.contactId,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/client/unlink-contact/http.ts
+++ b/src/aggregates/client/unlink-contact/http.ts
@@ -35,14 +35,19 @@ export function registerUnlinkContactRoutes(router: Router, eventStore: EventSto
     if (!result.ok) return res.status(400).json({ error: result.error });
 
     try {
-      await eventStore.appendEvent(result.value, 'client', result.value.clientId, 4);
+      const version = 4;
+      const pk = `client#${result.value.clientId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, version);
       const durationMs = Date.now() - startTime;
       console.log(`[ContactUnlinked]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         clientId: result.value.clientId,
         contactId: result.value.contactId,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/contact/create-contact/http.ts
+++ b/src/aggregates/contact/create-contact/http.ts
@@ -39,13 +39,18 @@ export function registerCreateContactRoutes(router: Router, eventStore: EventSto
     if (!result.ok) return res.status(400).json({ error: result.error });
 
     try {
-      await eventStore.appendEvent(result.value, 'contact', result.value.contactId, 1);
+      const version = 1;
+      const pk = `contact#${result.value.contactId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'contact', result.value.contactId, version);
       const durationMs = Date.now() - startTime;
       console.log(`[ContactCreated]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         contactId: result.value.contactId,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(201).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/contact/delete-contact/http.ts
+++ b/src/aggregates/contact/delete-contact/http.ts
@@ -38,13 +38,17 @@ export function registerDeleteContactRoutes(router: Router, eventStore: EventSto
 
     try {
       const version = 3; // TODO: real version
+      const pk = `contact#${cmd.contactId.value}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
       await eventStore.appendEvent(result.value, 'contact', cmd.contactId.value, version);
       const durationMs = Date.now() - startTime;
       console.log(`[ContactDeleted]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         contactId: cmd.contactId.value,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {

--- a/src/aggregates/contact/edit-contact/http.ts
+++ b/src/aggregates/contact/edit-contact/http.ts
@@ -39,13 +39,17 @@ export function registerEditContactRoutes(router: Router, eventStore: EventStore
 
     try {
       const version = 2; // TODO: real version
+      const pk = `contact#${cmd.contactId.value}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
       await eventStore.appendEvent(result.value, 'contact', cmd.contactId.value, version);
       const durationMs = Date.now() - startTime;
       console.log(`[ContactEdited]`, {
         traceId: trace.traceId,
         spanId: trace.spanId,
         contactId: cmd.contactId.value,
-        durationMs
+        durationMs,
+        pk,
+        sk
       });
       return res.status(200).json({ status: 'ok' });
     } catch (err) {


### PR DESCRIPTION
## Summary
- include PK and SK in all http endpoint logs that create events

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6857e81d36c88328bbf00d65016aa8c1