### PR TITLE
Add contract aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ src/
       ├─ get-case/
       ├─ open-cases/
       └─ project-case.ts
+   └─ contract/
+      ├─ create-contract/
+      ├─ add-version/
+      ├─ get-contract/
+      └─ project-contract.ts
 ```
 
 - **server.ts** registers each aggregate as an Express router.
@@ -43,11 +48,12 @@ src/
 
 ### Entities
 
-The project models three core aggregates:
+The project models four core aggregates:
 
 - **Contact** — `contactId`, `name`, `email` and `phone`.
 - **Client** — `clientId`, `name` and `industry`.
 - **Case** — `caseId`, `clientId`, `description`, `openedAt`, `closedAt` and a list of interactions.
+- **Contract** — `contractId`, `clientId` and a list of versions with supply details.
 
 ## Event Store
 
@@ -157,6 +163,21 @@ router.get('/cases/:id', async (req, res) => { /* ... */ });
 
 // 📌 GET /cases/open?clientId=... → List open cases
 router.get('/cases/open', async (req, res) => { /* ... */ });
+```
+
+## Contract aggregate
+
+Contracts belong to a client and are immutable. New details are stored as additional versions:
+
+```ts
+// 📌 POST /contracts → Create contract
+router.post('/contracts', async (req, res) => { /* ... */ });
+
+// 📌 POST /contracts/:id/versions → Add contract version
+router.post('/contracts/:id/versions', async (req, res) => { /* ... */ });
+
+// 📌 GET /contracts/:id → Fetch contract details
+router.get('/contracts/:id', async (req, res) => { /* ... */ });
 ```
 
 ## Running

--- a/src/aggregates/contract/add-version/http.ts
+++ b/src/aggregates/contract/add-version/http.ts
@@ -1,0 +1,75 @@
+import { Router } from 'express';
+import { handleAddContractVersion } from './index.js';
+import type { EventStore } from '../../../shared/event-store.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import { ContractId } from '../value-objects/contract-id.js';
+import { Cups } from '../value-objects/cups.js';
+import { Address } from '../value-objects/address.js';
+import { Tariff } from '../value-objects/tariff.js';
+import { Power } from '../value-objects/power.js';
+
+export function registerAddVersionRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
+
+  router.post('/contracts/:id/versions', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
+    let cmd;
+    try {
+      cmd = {
+        contractId: new ContractId(req.params.id),
+        startDate: req.body.startDate,
+        tariff: new Tariff(req.body.tariff),
+        power: new Power(Number(req.body.power)),
+        cups: new Cups(req.body.cups),
+        address: new Address(req.body.address),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleAddContractVersion(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      const events = await eventStore.getEventsForAggregate('contract', cmd.contractId.value);
+      const version = events.length + 1;
+      const pk = `contract#${cmd.contractId.value}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'contract', cmd.contractId.value, version);
+      const durationMs = Date.now() - startTime;
+      console.log(`[ContractVersionAdded]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        contractId: cmd.contractId.value,
+        durationMs,
+        pk,
+        sk
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[add-contract-version error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+}

--- a/src/aggregates/contract/add-version/index.ts
+++ b/src/aggregates/contract/add-version/index.ts
@@ -1,0 +1,48 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ContractId } from '../value-objects/contract-id.js';
+import { Cups } from '../value-objects/cups.js';
+import { Address } from '../value-objects/address.js';
+import { Tariff } from '../value-objects/tariff.js';
+import { Power } from '../value-objects/power.js';
+
+export type AddContractVersionCommand = {
+  contractId: ContractId;
+  startDate: string;
+  tariff: Tariff;
+  power: Power;
+  cups: Cups;
+  address: Address;
+  trace: TraceContext;
+};
+
+export type ContractVersionAddedEvent = {
+  type: 'ContractVersionAdded';
+  contractId: string;
+  startDate: string;
+  tariff: string;
+  power: number;
+  cups: string;
+  address: string;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export function handleAddContractVersion(
+  cmd: AddContractVersionCommand
+): Result<ContractVersionAddedEvent> {
+  const event: ContractVersionAddedEvent = {
+    type: 'ContractVersionAdded',
+    contractId: cmd.contractId.value,
+    startDate: cmd.startDate,
+    tariff: cmd.tariff.value,
+    power: cmd.power.value,
+    cups: cmd.cups.value,
+    address: cmd.address.value,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/aggregates/contract/create-contract/http.ts
+++ b/src/aggregates/contract/create-contract/http.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import { handleCreateContract } from './index.js';
+import type { EventStore } from '../../../shared/event-store.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import { ContractId } from '../value-objects/contract-id.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
+import { Cups } from '../value-objects/cups.js';
+import { Address } from '../value-objects/address.js';
+import { Tariff } from '../value-objects/tariff.js';
+import { Power } from '../value-objects/power.js';
+
+export function registerCreateContractRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
+
+  router.post('/contracts', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    const startTime = Date.now();
+    let cmd;
+    try {
+      cmd = {
+        contractId: new ContractId(req.body.contractId),
+        clientId: new ClientId(req.body.clientId),
+        startDate: req.body.startDate,
+        tariff: new Tariff(req.body.tariff),
+        power: new Power(Number(req.body.power)),
+        cups: new Cups(req.body.cups),
+        address: new Address(req.body.address),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleCreateContract(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      const version = 1;
+      const pk = `contract#${result.value.contractId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'contract', result.value.contractId, version);
+      const durationMs = Date.now() - startTime;
+      console.log(`[ContractCreated]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        contractId: result.value.contractId,
+        durationMs,
+        pk,
+        sk
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      const error = err as any;
+      if (
+        error.name === 'ConditionalCheckFailedException' ||
+        error.code === 'ConditionalCheckFailedException'
+      ) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      console.error('[create-contract error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+}

--- a/src/aggregates/contract/create-contract/index.ts
+++ b/src/aggregates/contract/create-contract/index.ts
@@ -1,0 +1,52 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ContractId } from '../value-objects/contract-id.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
+import { Cups } from '../value-objects/cups.js';
+import { Address } from '../value-objects/address.js';
+import { Tariff } from '../value-objects/tariff.js';
+import { Power } from '../value-objects/power.js';
+
+export type CreateContractCommand = {
+  contractId: ContractId;
+  clientId: ClientId;
+  startDate: string;
+  tariff: Tariff;
+  power: Power;
+  cups: Cups;
+  address: Address;
+  trace: TraceContext;
+};
+
+export type ContractCreatedEvent = {
+  type: 'ContractCreated';
+  contractId: string;
+  clientId: string;
+  startDate: string;
+  tariff: string;
+  power: number;
+  cups: string;
+  address: string;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export function handleCreateContract(
+  cmd: CreateContractCommand
+): Result<ContractCreatedEvent> {
+  const event: ContractCreatedEvent = {
+    type: 'ContractCreated',
+    contractId: cmd.contractId.value,
+    clientId: cmd.clientId.value,
+    startDate: cmd.startDate,
+    tariff: cmd.tariff.value,
+    power: cmd.power.value,
+    cups: cmd.cups.value,
+    address: cmd.address.value,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/aggregates/contract/get-contract/http.ts
+++ b/src/aggregates/contract/get-contract/http.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+import { projectContract } from '../project-contract.js';
+import { createTraceContext } from '../../../shared/trace.js';
+import type { EventStore } from '../../../shared/event-store.js';
+
+export function registerGetContractRoutes(router: Router, eventStore: EventStore) {
+  function extractTraceFromHeaders(headers: Record<string, unknown>) {
+    return createTraceContext({
+      traceId: headers['x-trace-id']?.toString(),
+      spanId: headers['x-span-id']?.toString(),
+      source: headers['x-source']?.toString() || 'api',
+      userId: headers['x-user-id']?.toString()
+    });
+  }
+
+  router.get('/contracts/:id', async (req, res) => {
+    const trace = extractTraceFromHeaders(req.headers);
+    const contractId = req.params.id;
+    const startTime = Date.now();
+
+    try {
+      const events = await eventStore.getEventsForAggregate('contract', contractId);
+      const state = projectContract(events);
+
+      if (!state) {
+        return res.status(404).json({ error: 'Contract not found' });
+      }
+
+      const durationMs = Date.now() - startTime;
+      console.log(`[ContractFetched]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        contractId,
+        durationMs
+      });
+      return res.status(200).json(state);
+    } catch (err) {
+      console.error('[get-contract error]', err);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+}

--- a/src/aggregates/contract/index.ts
+++ b/src/aggregates/contract/index.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import type { EventStore } from '../../shared/event-store.js';
+import type { Aggregate } from '../../shared/aggregate.js';
+import { registerCreateContractRoutes } from './create-contract/http.js';
+import { registerAddVersionRoutes } from './add-version/http.js';
+import { registerGetContractRoutes } from './get-contract/http.js';
+
+export class ContractAggregate implements Aggregate {
+  constructor(router: Router, eventStore: EventStore) {
+    registerCreateContractRoutes(router, eventStore);
+    registerAddVersionRoutes(router, eventStore);
+    registerGetContractRoutes(router, eventStore);
+  }
+}

--- a/src/aggregates/contract/project-contract.test.ts
+++ b/src/aggregates/contract/project-contract.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { projectContract } from './project-contract.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+const created = {
+  type: 'ContractCreated',
+  contractId: '1',
+  clientId: 'c1',
+  startDate: '2024-01-01',
+  tariff: 'PVPC',
+  power: 4.6,
+  cups: 'ES123456789',
+  address: 'Calle Falsa 123',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+const added = {
+  type: 'ContractVersionAdded',
+  contractId: '1',
+  startDate: '2024-02-01',
+  tariff: 'PVPC',
+  power: 5.0,
+  cups: 'ES123456789',
+  address: 'Calle Falsa 123',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+test('returns null for empty events', () => {
+  assert.equal(projectContract([]), null);
+});
+
+test('projects latest state', () => {
+  const state = projectContract([created, added]);
+  assert.equal(state?.versions.length, 2);
+  assert.equal(state?.clientId, 'c1');
+  assert.equal(state?.version, 2);
+});

--- a/src/aggregates/contract/project-contract.ts
+++ b/src/aggregates/contract/project-contract.ts
@@ -1,0 +1,45 @@
+export type ContractState = {
+  contractId: string;
+  clientId?: string;
+  versions: { startDate: string; tariff: string; power: number; cups: string; address: string }[];
+  version: number;
+};
+
+export function projectContract(events: any[]): ContractState | null {
+  if (!events.length) return null;
+
+  const state: ContractState = {
+    contractId: '',
+    versions: [],
+    version: 0
+  };
+
+  for (const event of events) {
+    switch (event.type) {
+      case 'ContractCreated':
+        state.contractId = event.contractId;
+        state.clientId = event.clientId;
+        state.versions.push({
+          startDate: event.startDate,
+          tariff: event.tariff,
+          power: event.power,
+          cups: event.cups,
+          address: event.address
+        });
+        state.version += 1;
+        break;
+      case 'ContractVersionAdded':
+        state.versions.push({
+          startDate: event.startDate,
+          tariff: event.tariff,
+          power: event.power,
+          cups: event.cups,
+          address: event.address
+        });
+        state.version += 1;
+        break;
+    }
+  }
+
+  return state;
+}

--- a/src/aggregates/contract/value-objects/address.ts
+++ b/src/aggregates/contract/value-objects/address.ts
@@ -1,0 +1,9 @@
+export class Address {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim().length < 5) {
+      throw new Error('address must be at least 5 characters');
+    }
+    this.value = value;
+  }
+}

--- a/src/aggregates/contract/value-objects/contract-id.ts
+++ b/src/aggregates/contract/value-objects/contract-id.ts
@@ -1,0 +1,9 @@
+export class ContractId {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim() === '') {
+      throw new Error('contractId is required');
+    }
+    this.value = value;
+  }
+}

--- a/src/aggregates/contract/value-objects/cups.ts
+++ b/src/aggregates/contract/value-objects/cups.ts
@@ -1,0 +1,9 @@
+export class Cups {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim().length < 5) {
+      throw new Error('cups must be at least 5 characters');
+    }
+    this.value = value;
+  }
+}

--- a/src/aggregates/contract/value-objects/power.ts
+++ b/src/aggregates/contract/value-objects/power.ts
@@ -1,0 +1,9 @@
+export class Power {
+  readonly value: number;
+  constructor(value: number) {
+    if (!value || value <= 0) {
+      throw new Error('power must be greater than 0');
+    }
+    this.value = value;
+  }
+}

--- a/src/aggregates/contract/value-objects/tariff.ts
+++ b/src/aggregates/contract/value-objects/tariff.ts
@@ -1,0 +1,9 @@
+export class Tariff {
+  readonly value: string;
+  constructor(value: string) {
+    if (!value || value.trim().length < 3) {
+      throw new Error('tariff must be at least 3 characters');
+    }
+    this.value = value;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { eventStore } from './shared/event-store.js';
 import { ClientAggregate } from './aggregates/client/index.js';
 import { ContactAggregate } from './aggregates/contact/index.js';
 import { CaseAggregate } from './aggregates/case/index.js';
+import { ContractAggregate } from './aggregates/contract/index.js';
 
 const app = express();
 app.use(express.json());
@@ -13,6 +14,7 @@ app.use('/api', router);
 new ContactAggregate(router, eventStore);
 new ClientAggregate(router, eventStore);
 new CaseAggregate(router, eventStore);
+new ContractAggregate(router, eventStore);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- model electricity contracts as an aggregate
- allow creating contracts and adding immutable versions
- expose contract endpoints
- register the aggregate in the server
- document the new aggregate and entity

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685969a447d483288f27961beca2a2d3