### PR TITLE
Add in-memory event store option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ export async function appendEvent(event: any, aggregateId: string, version: numb
 }
 ```
 
-The event store can run in **direct** mode (default) or in **batch** mode. Set `EVENT_STORE_MODE=batch` to buffer events locally and write them in bulk every 10 seconds. Reads always come from DynamoDB.
+The event store can run in **direct** mode (default) or in **batch** mode. Set `EVENT_STORE_MODE=batch` to buffer events locally and write them in bulk every 10 seconds.
+Reads normally go to DynamoDB but you can set `EVENT_STORE_ADAPTER=memory` to use an in-memory store instead. This adapter requires no infrastructure and is ideal for running the tests locally.
 
 Slices can **subscribe** to specific event types:
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "vite-node src/server.ts",
     "dev:batch": "EVENT_STORE_MODE=batch vite-node src/server.ts",
-    "test": "tsc --outDir dist && node --test dist/**/*.test.js",
+    "test": "EVENT_STORE_ADAPTER=memory tsc --outDir dist && node --test dist/**/*.test.js",
     "seed": "vite-node src/scripts/generate-data.ts"
   },
   "dependencies": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
-import { eventStore } from './shared/event-store.js';
+import { eventStore as dynamoEventStore } from './shared/event-store.js';
+import { memoryEventStore } from './shared/memory-event-store.js';
 import { ClientAggregate } from './aggregates/client/index.js';
 import { ContactAggregate } from './aggregates/contact/index.js';
 import { CaseAggregate } from './aggregates/case/index.js';
@@ -11,10 +12,14 @@ app.use(express.json());
 const router = express.Router();
 app.use('/api', router);
 
-new ContactAggregate(router, eventStore);
-new ClientAggregate(router, eventStore);
-new CaseAggregate(router, eventStore);
-new ContractAggregate(router, eventStore);
+const store = process.env.EVENT_STORE_ADAPTER === 'memory'
+  ? memoryEventStore
+  : dynamoEventStore;
+
+new ContactAggregate(router, store);
+new ClientAggregate(router, store);
+new CaseAggregate(router, store);
+new ContractAggregate(router, store);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/src/shared/memory-event-store.ts
+++ b/src/shared/memory-event-store.ts
@@ -1,0 +1,117 @@
+import type { AppendDirective, ProjectionDirective, EventStore } from './event-store.js';
+
+// In-memory collections for events and projections
+const events: Record<string, any>[] = [];
+const projections: Record<string, any>[] = [];
+
+// Subscribers just like in the DynamoDB implementation
+const subscribers: Record<string, ((event: any) => Promise<AppendDirective | void> | AppendDirective | void)[]> = {};
+const projectionSubscribers: Record<string, ((event: any) => Promise<ProjectionDirective | void> | ProjectionDirective | void)[]> = {};
+
+function logUndefinedPaths(obj: any, path: string[] = []) {
+  if (Array.isArray(obj)) {
+    obj.forEach((v, i) => logUndefinedPaths(v, [...path, String(i)]));
+  } else if (obj && typeof obj === 'object') {
+    for (const [key, value] of Object.entries(obj)) {
+      if (value === undefined) {
+        console.warn(`[undefined] ${[...path, key].join('.')}`);
+      } else {
+        logUndefinedPaths(value, [...path, key]);
+      }
+    }
+  }
+}
+
+function assertNoUndefined(obj: any, path: string[] = []) {
+  if (Array.isArray(obj)) {
+    obj.forEach((v, i) => assertNoUndefined(v, [...path, String(i)]));
+  } else if (obj && typeof obj === 'object') {
+    for (const [key, value] of Object.entries(obj)) {
+      if (value === undefined) {
+        const fullPath = [...path, key].join('.');
+        console.error(`[error] Undefined value at: ${fullPath}`);
+        throw new Error(`Cannot persist event: undefined at ${fullPath}`);
+      } else {
+        assertNoUndefined(value, [...path, key]);
+      }
+    }
+  }
+}
+
+export async function getEventsForAggregate(aggregateType: string, aggregateId: string): Promise<any[]> {
+  const pk = `${aggregateType}#${aggregateId}`;
+  return events.filter((e) => e.PK === pk).sort((a, b) => a.SK.localeCompare(b.SK));
+}
+
+export async function getEventsByPrefix(prefix: string): Promise<any[]> {
+  return events.filter((e) => (e.PK as string).startsWith(prefix));
+}
+
+export async function getProjection(aggregateType: string, aggregateId: string, name: string): Promise<any | null> {
+  const pk = `${aggregateType}#${aggregateId}`;
+  const item = projections.find((p) => p.PK === pk && p.SK === name);
+  return item || null;
+}
+
+export function subscribe(eventType: string, sub: (event: any) => Promise<AppendDirective | void> | AppendDirective | void) {
+  if (!subscribers[eventType]) subscribers[eventType] = [];
+  subscribers[eventType].push(sub);
+}
+
+export function subscribeProjection(eventType: string, sub: (event: any) => Promise<ProjectionDirective | void> | ProjectionDirective | void) {
+  if (!projectionSubscribers[eventType]) projectionSubscribers[eventType] = [];
+  projectionSubscribers[eventType].push(sub);
+}
+
+async function writeProjection(d: ProjectionDirective) {
+  const item = { PK: `${d.aggregateType}#${d.aggregateId}`, SK: d.name, ...d.projection };
+  const idx = projections.findIndex((p) => p.PK === item.PK && p.SK === item.SK);
+  if (idx >= 0) projections[idx] = item; else projections.push(item);
+}
+
+async function handleProjections(event: any) {
+  const subs = projectionSubscribers[event.type] || [];
+  for (const s of subs) {
+    const res = await Promise.resolve(s(event));
+    if (res && 'projection' in res) {
+      await writeProjection(res);
+    }
+  }
+}
+
+export async function appendEvent(event: any, aggregateType: string, aggregateId: string, version: number) {
+  const base = { PK: `${aggregateType}#${aggregateId}`, SK: `v${String(version).padStart(10, '0')}`, ...event };
+
+  const directives = await Promise.all((subscribers[event.type] || []).map((s) => Promise.resolve(s(event))));
+
+  if (directives.some((d) => d && 'cancel' in d && d.cancel)) {
+    return;
+  }
+
+  const items = [base];
+  for (const d of directives) {
+    if (d && 'event' in d) {
+      items.push({ PK: `${d.aggregateType}#${d.aggregateId}`, SK: `v${String(d.version).padStart(10, '0')}`, ...d.event });
+    }
+  }
+
+  for (const itm of items) {
+    logUndefinedPaths(itm);
+    assertNoUndefined(itm);
+    events.push(itm);
+  }
+
+  const evs = [event, ...directives.filter((d) => d && 'event' in d).map((d: any) => d.event)];
+  for (const ev of evs) {
+    await handleProjections(ev);
+  }
+}
+
+export const memoryEventStore: EventStore = {
+  appendEvent,
+  getEventsForAggregate,
+  getEventsByPrefix,
+  getProjection,
+  subscribe,
+  subscribeProjection
+};


### PR DESCRIPTION
## Summary
- add an in-memory implementation of the EventStore
- allow selecting the adapter through `EVENT_STORE_ADAPTER`
- update server to use the selected adapter
- mention the new option in the docs
- run tests using the memory adapter by default

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685b93279fdc832893a754b451883db3