### PR TITLE
Refactor trace extraction

### DIFF
--- a/src/aggregates/case/add-interaction/http.ts
+++ b/src/aggregates/case/add-interaction/http.ts
@@ -1,22 +1,14 @@
 import { Router } from 'express';
 import { handleAddInteraction } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { CaseId } from '../value-objects/case-id.js';
 import { Description } from '../value-objects/description.js';
 
 export function registerAddInteractionRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/cases/:id/interactions', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/case/close-case/http.ts
+++ b/src/aggregates/case/close-case/http.ts
@@ -1,21 +1,13 @@
 import { Router } from 'express';
 import { handleCloseCase } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { CaseId } from '../value-objects/case-id.js';
 
 export function registerCloseCaseRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/cases/:id/close', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/case/create-case/http.ts
+++ b/src/aggregates/case/create-case/http.ts
@@ -1,23 +1,15 @@
 import { Router } from 'express';
 import { handleCreateCase } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { CaseId } from '../value-objects/case-id.js';
 import { Description } from '../value-objects/description.js';
 import { ClientId } from '../../client/value-objects/client-id.js';
 
 export function registerCreateCaseRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/cases', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/case/get-case/http.ts
+++ b/src/aggregates/case/get-case/http.ts
@@ -1,20 +1,12 @@
 import { Router } from 'express';
 import { projectCase } from '../project-case.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import type { EventStore } from '../../../shared/event-store.js';
 
 export function registerGetCaseRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.get('/cases/:id', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const caseId = req.params.id;
     const startTime = Date.now();
 

--- a/src/aggregates/case/open-cases/http.ts
+++ b/src/aggregates/case/open-cases/http.ts
@@ -1,21 +1,13 @@
 import { Router } from 'express';
 import { projectOpenCases } from './index.js';
 import { OpenCasesProjection } from './subscription.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import type { EventStore } from '../../../shared/event-store.js';
 
 export function registerOpenCasesRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.get('/cases/open', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const clientId = req.query.clientId?.toString();
     const startTime = Date.now();
 

--- a/src/aggregates/client/create-client/http.ts
+++ b/src/aggregates/client/create-client/http.ts
@@ -1,23 +1,15 @@
 import { Router } from 'express';
 import { handleCreateClient } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
 import { Industry } from '../value-objects/industry.js';
 
 export function registerCreateClientRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/clients', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/client/edit-client/http.ts
+++ b/src/aggregates/client/edit-client/http.ts
@@ -1,23 +1,15 @@
 import { Router } from 'express';
 import { handleEditClient } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { Name } from '../value-objects/name.js';
 import { Industry } from '../value-objects/industry.js';
 
 export function registerEditClientRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.put('/clients/:id', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/client/get-client/http.ts
+++ b/src/aggregates/client/get-client/http.ts
@@ -1,20 +1,12 @@
 import { Router } from 'express';
 import { projectClient } from '../project-client.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import type { EventStore } from '../../../shared/event-store.js';
 
 export function registerGetClientRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.get('/clients/:id', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const clientId = req.params.id;
     const startTime = Date.now();
 

--- a/src/aggregates/client/link-contact/http.ts
+++ b/src/aggregates/client/link-contact/http.ts
@@ -1,22 +1,14 @@
 import { Router } from 'express';
 import { handleLinkContact } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { ContactId } from '../../contact/value-objects/contact-id.js';
 
 export function registerLinkContactRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/clients/:id/contacts', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/client/unlink-contact/http.ts
+++ b/src/aggregates/client/unlink-contact/http.ts
@@ -1,22 +1,14 @@
 import { Router } from 'express';
 import { handleUnlinkContact } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ClientId } from '../value-objects/client-id.js';
 import { ContactId } from '../../contact/value-objects/contact-id.js';
 
 export function registerUnlinkContactRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.delete('/clients/:id/contacts/:contactId', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/contact/create-contact/http.ts
+++ b/src/aggregates/contact/create-contact/http.ts
@@ -1,24 +1,16 @@
 import { Router } from 'express';
 import { handleCreateContact } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
 import { Phone } from '../value-objects/phone.js';
 
 export function registerCreateContactRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/contacts', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/contact/delete-contact/http.ts
+++ b/src/aggregates/contact/delete-contact/http.ts
@@ -1,22 +1,14 @@
 import { Router } from 'express';
 import { handleDeleteContact } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { ClientId } from '../../client/value-objects/client-id.js';
 
 export function registerDeleteContactRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.delete('/contacts/:id', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     const cascade = req.query.cascade === 'true';
     let cmd;

--- a/src/aggregates/contact/edit-contact/http.ts
+++ b/src/aggregates/contact/edit-contact/http.ts
@@ -1,24 +1,16 @@
 import { Router } from 'express';
 import { handleEditContact } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ContactId } from '../value-objects/contact-id.js';
 import { Name } from '../value-objects/name.js';
 import { Mail } from '../value-objects/mail.js';
 import { Phone } from '../value-objects/phone.js';
 
 export function registerEditContactRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.put('/contacts/:id', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/contact/get-contact/http.ts
+++ b/src/aggregates/contact/get-contact/http.ts
@@ -1,21 +1,12 @@
 import { Router } from 'express';
 import { projectContact } from '../project-contact.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import type { EventStore } from '../../../shared/event-store.js';
 
 export function registerGetContactRoutes(router: Router, eventStore: EventStore) {
-  // Reuse same helper as others
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.get('/contacts/:id', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const contactId = req.params.id;
     const startTime = Date.now();
 

--- a/src/aggregates/contract/add-version/http.ts
+++ b/src/aggregates/contract/add-version/http.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { handleAddContractVersion } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ContractId } from '../value-objects/contract-id.js';
 import { Cups } from '../value-objects/cups.js';
 import { Address } from '../value-objects/address.js';
@@ -9,17 +9,9 @@ import { Tariff } from '../value-objects/tariff.js';
 import { Power } from '../value-objects/power.js';
 
 export function registerAddVersionRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/contracts/:id/versions', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/contract/create-contract/http.ts
+++ b/src/aggregates/contract/create-contract/http.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { handleCreateContract } from './index.js';
 import type { EventStore } from '../../../shared/event-store.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import { ContractId } from '../value-objects/contract-id.js';
 import { ClientId } from '../../client/value-objects/client-id.js';
 import { Cups } from '../value-objects/cups.js';
@@ -10,17 +10,9 @@ import { Tariff } from '../value-objects/tariff.js';
 import { Power } from '../value-objects/power.js';
 
 export function registerCreateContractRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.post('/contracts', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const startTime = Date.now();
     let cmd;
     try {

--- a/src/aggregates/contract/get-contract/http.ts
+++ b/src/aggregates/contract/get-contract/http.ts
@@ -1,20 +1,12 @@
 import { Router } from 'express';
 import { projectContract } from '../project-contract.js';
-import { createTraceContext } from '../../../shared/trace.js';
+import { extractTraceContext } from '../../../shared/trace.js';
 import type { EventStore } from '../../../shared/event-store.js';
 
 export function registerGetContractRoutes(router: Router, eventStore: EventStore) {
-  function extractTraceFromHeaders(headers: Record<string, unknown>) {
-    return createTraceContext({
-      traceId: headers['x-trace-id']?.toString(),
-      spanId: headers['x-span-id']?.toString(),
-      source: headers['x-source']?.toString() || 'api',
-      userId: headers['x-user-id']?.toString()
-    });
-  }
 
   router.get('/contracts/:id', async (req, res) => {
-    const trace = extractTraceFromHeaders(req.headers);
+    const trace = extractTraceContext(req.headers);
     const contractId = req.params.id;
     const startTime = Date.now();
 

--- a/src/shared/trace.ts
+++ b/src/shared/trace.ts
@@ -24,3 +24,12 @@ export function createTraceContext(overrides: Partial<TraceContext> = {}): Trace
 
   return trace;
 }
+
+export function extractTraceContext(headers: Record<string, unknown>): TraceContext {
+  return createTraceContext({
+    traceId: headers['x-trace-id']?.toString(),
+    spanId: headers['x-span-id']?.toString(),
+    source: headers['x-source']?.toString() || 'api',
+    userId: headers['x-user-id']?.toString()
+  });
+}


### PR DESCRIPTION
## Summary
- centralize trace header parsing in shared helper
- use new helper across all HTTP handlers

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685d007918dc8328a9d61d091fc1042c