### PR TITLE
Add debt tracking and contract holder change

### DIFF
--- a/src/aggregates/client/add-debt/add-debt.test.ts
+++ b/src/aggregates/client/add-debt/add-debt.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleAddDebt } from './index.js';
+import { ClientId } from '../value-objects/client-id.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+test('fails when amount is invalid', () => {
+  const cmd = { clientId: new ClientId('1'), amount: 0, trace };
+  const res = handleAddDebt(cmd);
+  assert.equal(res.ok, false);
+});
+
+test('adds debt', () => {
+  const cmd = { clientId: new ClientId('1'), amount: 50, trace };
+  const res = handleAddDebt(cmd);
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.value.amount, 50);
+    assert.equal(res.value.clientId, '1');
+  }
+});

--- a/src/aggregates/client/add-debt/http.ts
+++ b/src/aggregates/client/add-debt/http.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import { handleAddDebt } from './index.js';
+import type { EventStore } from '../../../shared/event-store.js';
+import { extractTraceContext } from '../../../shared/trace.js';
+import { EventStoreConflictError } from '../../../shared/errors.js';
+import { ClientId } from '../value-objects/client-id.js';
+
+export function registerAddDebtRoutes(router: Router, eventStore: EventStore) {
+
+  router.post('/clients/:id/debt', async (req, res) => {
+    const trace = extractTraceContext(req.headers);
+    const startTime = Date.now();
+    let cmd;
+    try {
+      cmd = {
+        clientId: new ClientId(req.params.id),
+        amount: Number(req.body.amount),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handleAddDebt(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      const version = 5;
+      const pk = `client#${result.value.clientId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, version);
+      const durationMs = Date.now() - startTime;
+      console.log(`[DebtAdded]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        clientId: result.value.clientId,
+        amount: result.value.amount,
+        durationMs,
+        pk,
+        sk
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      if (err instanceof EventStoreConflictError) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      const error = err as any;
+      console.error('[add-debt error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+}
+

--- a/src/aggregates/client/add-debt/index.ts
+++ b/src/aggregates/client/add-debt/index.ts
@@ -1,0 +1,40 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+
+export type AddDebtCommand = {
+  clientId: ClientId;
+  amount: number;
+  trace: TraceContext;
+};
+
+export type DebtAddedEvent = {
+  type: 'DebtAdded';
+  clientId: string;
+  amount: number;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function validate(cmd: AddDebtCommand): Result<AddDebtCommand> {
+  if (cmd.amount <= 0 || isNaN(cmd.amount)) {
+    return { ok: false, error: 'amount must be greater than 0' };
+  }
+  return { ok: true, value: cmd };
+}
+
+export function handleAddDebt(cmd: AddDebtCommand): Result<DebtAddedEvent> {
+  const valid = validate(cmd);
+  if (!valid.ok) return { ok: false, error: valid.error };
+
+  const event: DebtAddedEvent = {
+    type: 'DebtAdded',
+    clientId: cmd.clientId.value,
+    amount: cmd.amount,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/aggregates/client/index.ts
+++ b/src/aggregates/client/index.ts
@@ -7,6 +7,8 @@ import { registerLinkContactRoutes } from './link-contact/http.js';
 import { registerUnlinkContactRoutes } from './unlink-contact/http.js';
 import { registerGetClientRoutes } from './get-client/http.js';
 import { registerUnlinkOnContactDeleted } from './unlink-contact/subscription.js';
+import { registerAddDebtRoutes } from './add-debt/http.js';
+import { registerPayDebtRoutes } from './pay-debt/http.js';
 
 export class ClientAggregate implements Aggregate {
   constructor(router: Router, eventStore: EventStore) {
@@ -15,6 +17,8 @@ export class ClientAggregate implements Aggregate {
     registerLinkContactRoutes(router, eventStore);
     registerUnlinkContactRoutes(router, eventStore);
     registerGetClientRoutes(router, eventStore);
+    registerAddDebtRoutes(router, eventStore);
+    registerPayDebtRoutes(router, eventStore);
     registerUnlinkOnContactDeleted(eventStore);
   }
 }

--- a/src/aggregates/client/pay-debt/http.ts
+++ b/src/aggregates/client/pay-debt/http.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import { handlePayDebt } from './index.js';
+import type { EventStore } from '../../../shared/event-store.js';
+import { extractTraceContext } from '../../../shared/trace.js';
+import { EventStoreConflictError } from '../../../shared/errors.js';
+import { ClientId } from '../value-objects/client-id.js';
+
+export function registerPayDebtRoutes(router: Router, eventStore: EventStore) {
+
+  router.post('/clients/:id/debt/pay', async (req, res) => {
+    const trace = extractTraceContext(req.headers);
+    const startTime = Date.now();
+    let cmd;
+    try {
+      cmd = {
+        clientId: new ClientId(req.params.id),
+        amount: Number(req.body.amount),
+        trace
+      };
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    const result = handlePayDebt(cmd);
+
+    if (!result.ok) return res.status(400).json({ error: result.error });
+
+    try {
+      const version = 6;
+      const pk = `client#${result.value.clientId}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'client', result.value.clientId, version);
+      const durationMs = Date.now() - startTime;
+      console.log(`[DebtPaid]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        clientId: result.value.clientId,
+        amount: result.value.amount,
+        durationMs,
+        pk,
+        sk
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      if (err instanceof EventStoreConflictError) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      const error = err as any;
+      console.error('[pay-debt error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+}
+

--- a/src/aggregates/client/pay-debt/index.ts
+++ b/src/aggregates/client/pay-debt/index.ts
@@ -1,0 +1,40 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ClientId } from '../value-objects/client-id.js';
+
+export type PayDebtCommand = {
+  clientId: ClientId;
+  amount: number;
+  trace: TraceContext;
+};
+
+export type DebtPaidEvent = {
+  type: 'DebtPaid';
+  clientId: string;
+  amount: number;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function validate(cmd: PayDebtCommand): Result<PayDebtCommand> {
+  if (cmd.amount <= 0 || isNaN(cmd.amount)) {
+    return { ok: false, error: 'amount must be greater than 0' };
+  }
+  return { ok: true, value: cmd };
+}
+
+export function handlePayDebt(cmd: PayDebtCommand): Result<DebtPaidEvent> {
+  const valid = validate(cmd);
+  if (!valid.ok) return { ok: false, error: valid.error };
+
+  const event: DebtPaidEvent = {
+    type: 'DebtPaid',
+    clientId: cmd.clientId.value,
+    amount: cmd.amount,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/aggregates/client/pay-debt/pay-debt.test.ts
+++ b/src/aggregates/client/pay-debt/pay-debt.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handlePayDebt } from './index.js';
+import { ClientId } from '../value-objects/client-id.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+test('fails when amount is invalid', () => {
+  const cmd = { clientId: new ClientId('1'), amount: 0, trace };
+  const res = handlePayDebt(cmd);
+  assert.equal(res.ok, false);
+});
+
+test('pays debt', () => {
+  const cmd = { clientId: new ClientId('1'), amount: 20, trace };
+  const res = handlePayDebt(cmd);
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.value.amount, 20);
+    assert.equal(res.value.clientId, '1');
+  }
+});

--- a/src/aggregates/client/project-client.test.ts
+++ b/src/aggregates/client/project-client.test.ts
@@ -21,13 +21,30 @@ const linked = {
   timestamp: new Date().toISOString()
 };
 
+const debtAdded = {
+  type: 'DebtAdded',
+  clientId: '1',
+  amount: 50,
+  trace,
+  timestamp: new Date().toISOString()
+};
+
+const debtPaid = {
+  type: 'DebtPaid',
+  clientId: '1',
+  amount: 20,
+  trace,
+  timestamp: new Date().toISOString()
+};
+
 test('returns null for empty events', () => {
   assert.equal(projectClient([]), null);
 });
 
 test('projects latest state', () => {
-  const state = projectClient([created, linked]);
+  const state = projectClient([created, linked, debtAdded, debtPaid]);
   assert.equal(state?.contactIds.length, 1);
   assert.equal(state?.industry, 'Software');
-  assert.equal(state?.version, 2);
+  assert.equal(state?.debt, 30);
+  assert.equal(state?.version, 4);
 });

--- a/src/aggregates/client/project-client.ts
+++ b/src/aggregates/client/project-client.ts
@@ -3,6 +3,7 @@ export type ClientState = {
   name?: string;
   industry?: string;
   contactIds: string[];
+  debt: number;
   version: number;
 };
 
@@ -12,6 +13,7 @@ export function projectClient(events: any[]): ClientState | null {
   const state: ClientState = {
     clientId: '',
     contactIds: [],
+    debt: 0,
     version: 0
   };
 
@@ -41,6 +43,16 @@ export function projectClient(events: any[]): ClientState | null {
         state.contactIds = state.contactIds.filter(
           (id) => id !== event.contactId
         );
+        state.version += 1;
+        break;
+
+      case 'DebtAdded':
+        state.debt += event.amount;
+        state.version += 1;
+        break;
+
+      case 'DebtPaid':
+        state.debt = Math.max(0, state.debt - event.amount);
         state.version += 1;
         break;
     }

--- a/src/aggregates/contract/change-holder/change-holder.test.ts
+++ b/src/aggregates/contract/change-holder/change-holder.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleChangeHolder } from './index.js';
+import { ContractId } from '../value-objects/contract-id.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
+
+const trace = { traceId: 't', spanId: 's', timestamp: new Date().toISOString() };
+
+test('fails when new client is same as old', () => {
+  const cmd = {
+    contractId: new ContractId('1'),
+    oldClientId: new ClientId('c1'),
+    newClientId: new ClientId('c1'),
+    trace
+  };
+  const res = handleChangeHolder(cmd);
+  assert.equal(res.ok, false);
+});
+
+test('changes holder', () => {
+  const cmd = {
+    contractId: new ContractId('1'),
+    oldClientId: new ClientId('c1'),
+    newClientId: new ClientId('c2'),
+    trace
+  };
+  const res = handleChangeHolder(cmd);
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.value.contractId, '1');
+    assert.equal(res.value.newClientId, 'c2');
+  }
+});

--- a/src/aggregates/contract/change-holder/http.ts
+++ b/src/aggregates/contract/change-holder/http.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import { handleChangeHolder } from './index.js';
+import type { EventStore } from '../../../shared/event-store.js';
+import { extractTraceContext } from '../../../shared/trace.js';
+import { EventStoreConflictError } from '../../../shared/errors.js';
+import { ContractId } from '../value-objects/contract-id.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
+import { projectContract } from '../project-contract.js';
+import { projectClient } from '../../client/project-client.js';
+
+export function registerChangeHolderRoutes(router: Router, eventStore: EventStore) {
+
+  router.post('/contracts/:id/change-holder', async (req, res) => {
+    const trace = extractTraceContext(req.headers);
+    const startTime = Date.now();
+    let contractId: ContractId;
+    let newClient: ClientId;
+    try {
+      contractId = new ContractId(req.params.id);
+      newClient = new ClientId(req.body.clientId);
+    } catch (err) {
+      const error = err as Error;
+      return res.status(400).json({ error: error.message });
+    }
+
+    try {
+      const events = await eventStore.getEventsForAggregate('contract', contractId.value);
+      const state = projectContract(events);
+      if (!state || !state.clientId) {
+        return res.status(404).json({ error: 'Contract not found' });
+      }
+
+      const clientEvents = await eventStore.getEventsForAggregate('client', state.clientId);
+      const clientState = projectClient(clientEvents);
+      if (clientState && (clientState.debt || 0) > 0) {
+        return res.status(400).json({ error: 'Client has outstanding debt' });
+      }
+
+      const cmd = {
+        contractId,
+        oldClientId: new ClientId(state.clientId),
+        newClientId: newClient,
+        trace
+      };
+      const result = handleChangeHolder(cmd);
+      if (!result.ok) return res.status(400).json({ error: result.error });
+
+      const version = events.length + 1;
+      const pk = `contract#${contractId.value}`;
+      const sk = `v${String(version).padStart(10, '0')}`;
+      await eventStore.appendEvent(result.value, 'contract', contractId.value, version);
+      const durationMs = Date.now() - startTime;
+      console.log(`[ContractHolderChanged]`, {
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        contractId: contractId.value,
+        newClientId: newClient.value,
+        durationMs,
+        pk,
+        sk
+      });
+      return res.status(201).json({ status: 'ok' });
+    } catch (err) {
+      if (err instanceof EventStoreConflictError) {
+        return res.status(409).json({
+          error: 'Event already exists — possible duplicate or stale version.'
+        });
+      }
+
+      const error = err as any;
+      console.error('[change-holder error]', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+}
+

--- a/src/aggregates/contract/change-holder/index.ts
+++ b/src/aggregates/contract/change-holder/index.ts
@@ -1,0 +1,44 @@
+import { TraceContext } from '../../../shared/trace.js';
+import { ContractId } from '../value-objects/contract-id.js';
+import { ClientId } from '../../client/value-objects/client-id.js';
+
+export type ChangeHolderCommand = {
+  contractId: ContractId;
+  oldClientId: ClientId;
+  newClientId: ClientId;
+  trace: TraceContext;
+};
+
+export type ContractHolderChangedEvent = {
+  type: 'ContractHolderChanged';
+  contractId: string;
+  oldClientId: string;
+  newClientId: string;
+  trace: TraceContext;
+  timestamp: string;
+};
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function validate(cmd: ChangeHolderCommand): Result<ChangeHolderCommand> {
+  if (cmd.oldClientId.value === cmd.newClientId.value) {
+    return { ok: false, error: 'new client must differ from current client' };
+  }
+  return { ok: true, value: cmd };
+}
+
+export function handleChangeHolder(cmd: ChangeHolderCommand): Result<ContractHolderChangedEvent> {
+  const valid = validate(cmd);
+  if (!valid.ok) return { ok: false, error: valid.error };
+
+  const event: ContractHolderChangedEvent = {
+    type: 'ContractHolderChanged',
+    contractId: cmd.contractId.value,
+    oldClientId: cmd.oldClientId.value,
+    newClientId: cmd.newClientId.value,
+    trace: cmd.trace,
+    timestamp: new Date().toISOString()
+  };
+
+  return { ok: true, value: event };
+}

--- a/src/aggregates/contract/index.ts
+++ b/src/aggregates/contract/index.ts
@@ -4,11 +4,13 @@ import type { Aggregate } from '../../shared/aggregate.js';
 import { registerCreateContractRoutes } from './create-contract/http.js';
 import { registerAddVersionRoutes } from './add-version/http.js';
 import { registerGetContractRoutes } from './get-contract/http.js';
+import { registerChangeHolderRoutes } from './change-holder/http.js';
 
 export class ContractAggregate implements Aggregate {
   constructor(router: Router, eventStore: EventStore) {
     registerCreateContractRoutes(router, eventStore);
     registerAddVersionRoutes(router, eventStore);
+    registerChangeHolderRoutes(router, eventStore);
     registerGetContractRoutes(router, eventStore);
   }
 }

--- a/src/aggregates/contract/project-contract.test.ts
+++ b/src/aggregates/contract/project-contract.test.ts
@@ -29,13 +29,22 @@ const added = {
   timestamp: new Date().toISOString()
 };
 
+const holderChanged = {
+  type: 'ContractHolderChanged',
+  contractId: '1',
+  oldClientId: 'c1',
+  newClientId: 'c2',
+  trace,
+  timestamp: new Date().toISOString()
+};
+
 test('returns null for empty events', () => {
   assert.equal(projectContract([]), null);
 });
 
 test('projects latest state', () => {
-  const state = projectContract([created, added]);
+  const state = projectContract([created, added, holderChanged]);
   assert.equal(state?.versions.length, 2);
-  assert.equal(state?.clientId, 'c1');
-  assert.equal(state?.version, 2);
+  assert.equal(state?.clientId, 'c2');
+  assert.equal(state?.version, 3);
 });

--- a/src/aggregates/contract/project-contract.ts
+++ b/src/aggregates/contract/project-contract.ts
@@ -38,6 +38,11 @@ export function projectContract(events: any[]): ContractState | null {
         });
         state.version += 1;
         break;
+
+      case 'ContractHolderChanged':
+        state.clientId = event.newClientId;
+        state.version += 1;
+        break;
     }
   }
 


### PR DESCRIPTION
## Summary
- add DebtAdded and DebtPaid events for clients
- implement ChangeHolder event on contracts
- update projections to account for new events
- expose HTTP routes for adding/paying debt and changing contract holder
- register new slices in aggregates
- add unit tests for the new handlers and projections

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685d0fc762988328856f9c3a2dc8fda2